### PR TITLE
[FIX] [no-unused-vars] address more false positives

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -123,7 +123,9 @@ module.exports = {
                     break;
 
                 case "TSTypeParameter": {
-                    markTypeAnnotationAsUsed(annotation.constraint);
+                    if (annotation.constraint) {
+                        markTypeAnnotationAsUsed(annotation.constraint);
+                    }
                     break;
                 }
                 case "TSMappedType": {
@@ -211,6 +213,18 @@ module.exports = {
         }
 
         /**
+         * Checks the given expression and marks any type parameters as used.
+         * @param {ASTNode} node the relevant AST node.
+         * @returns {void}
+         * @private
+         */
+        function markExpressionAsUsed(node) {
+            if (node.typeParameters && node.typeParameters.params) {
+                node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
+            }
+        }
+
+        /**
          * Checks the given interface and marks it as used.
          * Generic arguments are also included in the check.
          * This is used when interfaces are extending other interfaces.
@@ -231,19 +245,22 @@ module.exports = {
         }
 
         /**
-         * Checks the given function return type and marks it as used.
+         * Checks the given function and marks return types and type parameter constraints as used.
          * @param {ASTNode} node the relevant AST node.
          * @returns {void}
          * @private
          */
-        function markFunctionReturnTypeAsUsed(node) {
+        function markFunctionOptionsAsUsed(node) {
+            if (node.typeParameters && node.typeParameters.params) {
+                node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
+            }
             if (node.returnType) {
                 markTypeAnnotationAsUsed(node.returnType);
             }
         }
 
         /**
-         * Checks the given class and marks super classes, interfaces and decoratores as used.
+         * Checks the given class and marks super classes, interfaces, type parameter constraints and decorators as used.
          * @param {ASTNode} node the relevant AST node.
          * @returns {void}
          * @private
@@ -281,17 +298,12 @@ module.exports = {
                 }
             },
 
-            FunctionDeclaration: markFunctionReturnTypeAsUsed,
-            FunctionExpression: markFunctionReturnTypeAsUsed,
-            ArrowFunctionExpression: markFunctionReturnTypeAsUsed,
+            FunctionDeclaration: markFunctionOptionsAsUsed,
+            FunctionExpression: markFunctionOptionsAsUsed,
+            ArrowFunctionExpression: markFunctionOptionsAsUsed,
 
-            CallExpression(node) {
-                if (node.typeParameters && node.typeParameters.params) {
-                    node.typeParameters.params.forEach(
-                        markTypeAnnotationAsUsed
-                    );
-                }
-            },
+            CallExpression: markExpressionAsUsed,
+            NewExpression: markExpressionAsUsed,
 
             Decorator: markDecoratorAsUsed,
             TSInterfaceHeritage: markExtendedInterfaceAsUsed,

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -220,6 +220,7 @@ console.log(a);
 import { Nullable } from 'nullable';
 import { Component } from 'react';
 class Foo implements Component<Nullable>{};
+
 new Foo();
 		`,
         `
@@ -340,6 +341,38 @@ export const map: { [name in Foo]: Bar } = {
     b: 2,
     c: 3
 }
+        `,
+        `
+import { Nullable } from 'nullable';
+class A<T> {
+    bar: T
+}
+new A<Nullable>();
+        `,
+        `
+import { Nullable } from 'nullable';
+import { SomeOther } from 'other';
+function foo<T extends Nullable>() {
+}
+foo<SomeOther>();
+        `,
+        `
+import { Nullable } from 'nullable';
+import { SomeOther } from 'other';
+class A<T extends Nullable> {
+    bar: T;
+}
+new A<SomeOther>();
+        `,
+        `
+import { Nullable } from 'nullable';
+import { SomeOther } from 'other';
+interface A<T extends Nullable> {
+    bar: T;
+}
+export const a: A<SomeOther> = {
+    foo: "bar"
+};
         `
     ],
 


### PR DESCRIPTION
Fixes false positives demonstrated in these test cases (type parameter in new expression, type parameter constraints):
```javascript
import { Nullable } from 'nullable';
class A<T> {
    bar: T
}
new A<Nullable>();
```
```javascript
import { Nullable } from 'nullable';
import { SomeOther } from 'other';
function foo<T extends Nullable>() {
}
foo<SomeOther>();
```
```javascript
import { Nullable } from 'nullable';
import { SomeOther } from 'other';
class A<T extends Nullable> {
    bar: T;
}
new A<SomeOther>();
```
```javascript
import { Nullable } from 'nullable';
import { SomeOther } from 'other';
interface A<T extends Nullable> {
    bar: T;
}
const a: A<SomeOther> = {
    foo: "bar"
};
console.log(a);
```