### PR TITLE
Fix type param constraint. Support defaults.

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -125,7 +125,8 @@ module.exports = {
                 case "TSTypeParameter": {
                     if (annotation.constraint) {
                         markTypeAnnotationAsUsed(annotation.constraint);
-                    } else if (annotation.default) {
+                    }
+                    if (annotation.default) {
                         markTypeAnnotationAsUsed(annotation.default);
                     }
                     break;

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -123,7 +123,11 @@ module.exports = {
                     break;
 
                 case "TSTypeParameter": {
-                    markTypeAnnotationAsUsed(annotation.constraint);
+                    if (annotation.constraint) {
+                        markTypeAnnotationAsUsed(annotation.constraint);
+                    } else if (annotation.default) {
+                        markTypeAnnotationAsUsed(annotation.default);
+                    }
                     break;
                 }
                 case "TSMappedType": {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -332,6 +332,34 @@ class Baz<T extends Foo & Bar> {}
 new Baz<any>()
         `,
         `
+import { Foo } from './types';
+
+class Bar<T = Foo> {}
+
+new Bar<number>()
+        `,
+        `
+import { Foo } from './types';
+
+class Foo<T = any> {}
+
+new Foo()
+        `,
+        `
+import { Foo } from './types';
+
+class Foo<T = {}> {}
+
+new Foo()
+        `,
+        `
+import { Foo } from './types';
+
+class Foo<T extends {} = {}> {}
+
+new Foo()
+        `,
+        `
 type Foo = "a" | "b" | "c"
 type Bar = number
 


### PR DESCRIPTION
After updating to the latest, I started seeing this error a lot.

```
TypeError: Cannot read property 'typeAnnotation' of undefined
    at markTypeAnnotationAsUsed (/Users/Miles/Sites/boost/node_modules/eslint-plugin-typescript/lib/rules/no-unused-vars.js:71:37)
    at markTypeAnnotationAsUsed (/Users/Miles/Sites/boost/node_modules/eslint-plugin-typescript/lib/rules/no-unused-vars.js:126:21)
    at Array.forEach (<anonymous>)
    at markClassOptionsAsUsed (/Users/Miles/Sites/boost/node_modules/eslint-plugin-typescript/lib/rules/no-unused-vars.js:260:44)
    at listeners.(anonymous function).forEach.listener (/Users/Miles/Sites/boost/node_modules/eslint/lib/util/safe-emitter.js:45:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/Miles/Sites/boost/node_modules/eslint/lib/util/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/Miles/Sites/boost/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/Users/Miles/Sites/boost/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/Users/Miles/Sites/boost/node_modules/eslint/lib/util/node-event-generator.js:294:14)
```

Seems like some params have an undefined `constraint`, so add a check for it.

I also added support for defaults, `<T = Foo>`, since that doesn't seem to be covered.