### PR TITLE
[DOCS] Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Report an issue
+labels: 
+
+---
+
+<!--
+If you have a problem with a specific rule, please begin your issue title with [rulename] to make it easier to search for.
+I.e. "[no-unused-vars] False positive when fooing the bar" 
+-->
+
+**Repro**
+<!--
+Include a minimal reproduction case.
+Please try to avoid code that isn't directly related to the bug, as it makes it harder to investigate.
+-->
+```JSON
+{
+  "rules": {
+    "typescript/<rule>": "<setting>"
+  }
+}
+```
+
+```TS
+// your repro code case
+```
+
+
+**Expected Result**
+
+
+**Actual Result**
+
+
+
+**Additional Info**
+
+
+
+** Versions **
+| package                    | version |
+| -------------------------- | ------- |
+| `eslint-plugin-typescript` | `X.Y.Z` |
+| `typescript-eslint-parser` | `X.Y.Z` |
+| `typescript`               | `X.Y.Z` |

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: 
+
+---
+
+I'd like to propose a **new rule / change to an existing rule**.
+
+**Description**
+<!-- 
+A clear and concise description of what you would like implemented.
+Code samples can help immensely in describing painting a picture.
+-->


### PR DESCRIPTION
I was running through triaging the existing issues, and I noticed there was a wide variety of formatting and level of information.

This is just an attempt to help make it easier to maintain.

Let me know if you think there is too much / too little / etc in these templates.