### PR TITLE
[FIX][no-unused-vars] assume constructor parameter args are used

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -301,6 +301,11 @@ module.exports = {
                 }
             },
 
+            TSParameterProperty(node) {
+                // just assume parameter properties are used
+                markVariableAsUsed(context, node.parameter.name);
+            },
+
             FunctionDeclaration: markFunctionOptionsAsUsed,
             FunctionExpression: markFunctionOptionsAsUsed,
             ArrowFunctionExpression: markFunctionOptionsAsUsed,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "docs:check": "eslint-docs check",
     "format": "prettier --write --tab-width 4 lib/**/*.js tests/**/*.js",
     "mocha": "mocha tests --recursive --reporter=dot",
-    "test": "npm run lint && npm run mocha && npm run docs:check",
+    "pretest": "npm run lint",
+    "test": "mocha tests --recursive --reporter=dot",
+    "posttest": "npm run docs:check",
     "precommit": "npm test && lint-staged"
   },
   "dependencies": {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -401,6 +401,46 @@ interface A<T extends Nullable> {
 export const a: A<SomeOther> = {
     foo: "bar"
 };
+        `,
+        // https://github.com/nzakas/eslint-plugin-typescript/issues/150
+        `
+export class App {
+    constructor(private logger: Logger) {
+        console.log(this.logger);
+    }
+}
+        `,
+        `
+export class App {
+    constructor(bar: string);
+    constructor(private logger: Logger) {
+        console.log(this.logger);
+    }
+}
+        `,
+        `
+export class App {
+    constructor(baz: string, private logger: Logger) {
+        console.log(baz);
+        console.log(this.logger);
+    }
+}
+        `,
+        `
+export class App {
+    constructor(baz: string, private logger: Logger, private bar: () => void) {
+        console.log(this.logger);
+        this.bar();
+    }
+}
+        `,
+        `
+export class App {
+    constructor(private logger: Logger) {}
+    meth() {
+        console.log(this.logger);
+    }
+}
         `
     ],
 


### PR DESCRIPTION
Fixes #150 

Whilst `TSParameterProperty`s are arguments, they are also technically class properties.
`no-unused-vars` has no handling for class properties, so just mark them as used.