### PR TITLE
Migrate typescript-eslint-parser to 21.0.2

### DIFF
--- a/lib/rules/no-explicit-any.js
+++ b/lib/rules/no-explicit-any.js
@@ -18,89 +18,19 @@ module.exports = {
             extraDescription: [util.tslintRule("no-any")],
             category: "TypeScript",
             url:
-                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-explicit-any.md",
+                "https://github.com/bradzacher/eslint-plugin-typescript/blob/master/docs/rules/no-explicit-any.md",
         },
         schema: [],
     },
 
     create(context) {
-        //----------------------------------------------------------------------
-        // Helpers
-        //----------------------------------------------------------------------
-
-        /**
-         * Checks if the node has a type annotation of type any.
-         * @param {ASTNode} node The node being validated.
-         * @returns {void}
-         * @private
-         */
-        function checkGenericNodeForAnnotation(node) {
-            if (node.type === "TSAnyKeyword") {
+        return {
+            TSAnyKeyword(node) {
                 context.report({
                     node,
                     message: "Unexpected any. Specify a different type.",
                 });
-            } else if (node.type === "TSArrayType") {
-                checkGenericNodeForAnnotation(node.elementType);
-            } else if (
-                node.type === "TSUnionType" ||
-                node.type === "TSIntersectionType"
-            ) {
-                node.types.forEach(type => {
-                    checkGenericNodeForAnnotation(type);
-                });
-            } else if (node.type === "TSTypeReference") {
-                if (node.typeParameters) {
-                    // handles generics
-                    node.typeParameters.params.forEach(param => {
-                        checkGenericNodeForAnnotation(param);
-                    });
-                } else if (node.typeName) {
-                    // handles non generics
-                    checkGenericNodeForAnnotation(node.typeName);
-                }
-            } else if (node.type === "GenericTypeAnnotation") {
-                if (node.typeParameters) {
-                    node.typeParameters.params.forEach(param => {
-                        checkGenericNodeForAnnotation(param);
-                    });
-                } else {
-                    checkGenericNodeForAnnotation(node.id);
-                }
-            }
-        }
-
-        /**
-         * Checks if a function node used the any type
-         * @param {ASTNode} node The node representing a function.
-         * @returns {void}
-         * @private
-         */
-        function checkFunctionReturnTypeForAnnotation(node) {
-            if (node.returnType) {
-                checkGenericNodeForAnnotation(node.returnType.typeAnnotation);
-            }
-        }
-
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-        return {
-            Identifier(node) {
-                if (node.typeAnnotation) {
-                    checkGenericNodeForAnnotation(
-                        node.typeAnnotation.typeAnnotation
-                    );
-                }
             },
-            TSTypeAnnotation(node) {
-                if (node.typeAnnotation) {
-                    checkGenericNodeForAnnotation(node.typeAnnotation);
-                }
-            },
-            FunctionDeclaration: checkFunctionReturnTypeForAnnotation,
-            FunctionExpression: checkFunctionReturnTypeForAnnotation,
-            ArrowFunctionExpression: checkFunctionReturnTypeForAnnotation,
         };
     },
 };

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -4,41 +4,6 @@
  */
 "use strict";
 
-/**
- * Record that a particular variable has been used in code
- *
- * @param {Object} context The current rule context.
- * @param {string} name The name of the variable to mark as used.
- * @returns {boolean} True if the variable was found and marked as used, false if not.
- */
-function markVariableAsUsed(context, name) {
-    let scope = context.getScope();
-    let variables;
-    let i;
-    let len;
-    let found = false;
-
-    // Special Node.js scope means we need to start one level deeper
-    if (scope.type === "global") {
-        while (scope.childScopes.length) {
-            scope = scope.childScopes[0];
-        }
-    }
-
-    do {
-        variables = scope.variables;
-        for (i = 0, len = variables.length; i < len; i++) {
-            if (variables[i].name === name) {
-                variables[i].eslintUsed = true;
-                found = true;
-            }
-        }
-        scope = scope.upper;
-    } while (scope);
-
-    return found;
-}
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -57,227 +22,20 @@ module.exports = {
     },
 
     create(context) {
-        //----------------------------------------------------------------------
-        // Helpers
-        //----------------------------------------------------------------------
-
         /**
-         * Checks the given node type annotation and marks it as used.
-         * @param {ASTNode} node the relevant AST node.
+         * Mark this function parameter as used
+         * @param {Identifier} node The node currently being traversed
          * @returns {void}
-         * @private
          */
-        function markTypeAnnotationAsUsed(node) {
-            const annotation = node.typeAnnotation || node;
-
-            switch (annotation.type) {
-                case "Identifier": {
-                    markVariableAsUsed(context, annotation.name);
-                    break;
-                }
-                case "TSArrayType": {
-                    markTypeAnnotationAsUsed(annotation.elementType);
-                    break;
-                }
-                case "TSQualifiedName": {
-                    markTypeAnnotationAsUsed(annotation.left);
-                    markTypeAnnotationAsUsed(annotation.right);
-                    break;
-                }
-                case "TSTypeReference": {
-                    if (annotation.typeName.type === "TSArrayType") {
-                        markTypeAnnotationAsUsed(
-                            annotation.typeName.elementType
-                        );
-                    } else if (annotation.typeName.type === "TSQualifiedName") {
-                        markTypeAnnotationAsUsed(annotation.typeName);
-                    } else {
-                        markVariableAsUsed(context, annotation.typeName.name);
-                        if (
-                            annotation.typeParameters &&
-                            annotation.typeParameters.params
-                        ) {
-                            annotation.typeParameters.params.forEach(param => {
-                                markTypeAnnotationAsUsed(param);
-                            });
-                        }
-                    }
-
-                    break;
-                }
-                case "TSTypeLiteral": {
-                    annotation.members.forEach(member => {
-                        if (member.typeAnnotation) {
-                            markTypeAnnotationAsUsed(member.typeAnnotation);
-                        }
-                    });
-
-                    break;
-                }
-                case "TSUnionType":
-                case "TSIntersectionType":
-                    annotation.types.forEach(type => {
-                        markTypeAnnotationAsUsed(type);
-                    });
-
-                    break;
-
-                case "TSTypeParameter": {
-                    if (annotation.constraint) {
-                        markTypeAnnotationAsUsed(annotation.constraint);
-                    }
-                    if (annotation.default) {
-                        markTypeAnnotationAsUsed(annotation.default);
-                    }
-                    break;
-                }
-                case "TSMappedType": {
-                    markTypeAnnotationAsUsed(annotation.typeAnnotation);
-                    markTypeAnnotationAsUsed(annotation.typeParameter);
-                    break;
-                }
-                default:
-                    break;
-            }
-        }
-
-        /**
-         * Checks the given decorator and marks it as used.
-         * @param {ASTNode} node The relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markDecoratorAsUsed(node) {
-            /**
-             * Decorator
-             */
+        function markThisParameterAsUsed(node) {
             if (node.name) {
-                markVariableAsUsed(context, node.name);
-                return;
-            }
+                const variable = context
+                    .getScope()
+                    .variables.find(scopeVar => scopeVar.name === node.name);
 
-            if (node.expression && node.expression.name) {
-                markVariableAsUsed(context, node.expression.name);
-                return;
-            }
-
-            /**
-             * Decorator Factory
-             */
-            if (node.callee && node.callee.name) {
-                markVariableAsUsed(context, node.callee.name);
-            }
-
-            if (
-                node.expression &&
-                node.expression.callee &&
-                node.expression.callee.name
-            ) {
-                markVariableAsUsed(context, node.expression.callee.name);
-            }
-        }
-
-        /**
-         * Checks the given interface and marks it as used.
-         * Generic arguments are also included in the check.
-         * @param {ASTNode} node The relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markImplementedInterfaceAsUsed(node) {
-            if (!node || !node.id || !node.id.name) {
-                return;
-            }
-            markVariableAsUsed(context, node.id.name);
-
-            if (!node.typeParameters || !node.typeParameters.params) {
-                return;
-            }
-            node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
-        }
-
-        /**
-         * Checks the given class has a super class and marks it as used.
-         * Generic arguments are also included in the check.
-         * @param {ASTNode} node The relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markSuperClassAsUsed(node) {
-            if (!node.superClass) {
-                return;
-            }
-            markVariableAsUsed(context, node.superClass.name);
-
-            if (!node.superTypeParameters || !node.superTypeParameters.params) {
-                return;
-            }
-            node.superTypeParameters.params.forEach(markTypeAnnotationAsUsed);
-        }
-
-        /**
-         * Checks the given expression and marks any type parameters as used.
-         * @param {ASTNode} node the relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markExpressionAsUsed(node) {
-            if (node.typeParameters && node.typeParameters.params) {
-                node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
-            }
-        }
-
-        /**
-         * Checks the given interface and marks it as used.
-         * Generic arguments are also included in the check.
-         * This is used when interfaces are extending other interfaces.
-         * @param {ASTNode} node the relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markExtendedInterfaceAsUsed(node) {
-            if (!node || !node.id || !node.id.name) {
-                return;
-            }
-            markVariableAsUsed(context, node.id.name);
-
-            if (!node.typeParameters || !node.typeParameters.params) {
-                return;
-            }
-            node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
-        }
-
-        /**
-         * Checks the given function and marks return types and type parameter constraints as used.
-         * @param {ASTNode} node the relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markFunctionOptionsAsUsed(node) {
-            if (node.typeParameters && node.typeParameters.params) {
-                node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
-            }
-            if (node.returnType) {
-                markTypeAnnotationAsUsed(node.returnType);
-            }
-        }
-
-        /**
-         * Checks the given class and marks super classes, interfaces, type parameter constraints and decorators as used.
-         * @param {ASTNode} node the relevant AST node.
-         * @returns {void}
-         * @private
-         */
-        function markClassOptionsAsUsed(node) {
-            markSuperClassAsUsed(node);
-            if (node.implements) {
-                node.implements.forEach(markImplementedInterfaceAsUsed);
-            }
-            if (node.decorators) {
-                node.decorators.forEach(markDecoratorAsUsed);
-            }
-            if (node.typeParameters && node.typeParameters.params) {
-                node.typeParameters.params.forEach(markTypeAnnotationAsUsed);
+                if (variable) {
+                    variable.eslintUsed = true;
+                }
             }
         }
 
@@ -285,50 +43,17 @@ module.exports = {
         // Public
         //----------------------------------------------------------------------
         return {
-            Identifier(node) {
-                if (node.typeAnnotation) {
-                    markTypeAnnotationAsUsed(node.typeAnnotation);
-                }
-
-                if (node.decorators) {
-                    node.decorators.forEach(markDecoratorAsUsed);
-                }
+            "FunctionDeclaration Identifier[name='this']": markThisParameterAsUsed,
+            "FunctionExpression Identifier[name='this']": markThisParameterAsUsed,
+            "TSTypeReference Identifier"(node) {
+                context.markVariableAsUsed(node.name);
             },
-
-            TSTypeAnnotation(node) {
-                if (node.typeAnnotation) {
-                    markTypeAnnotationAsUsed(node.typeAnnotation);
-                }
+            "ClassImplements Identifier"(node) {
+                context.markVariableAsUsed(node.name);
             },
-
-            TSParameterProperty(node) {
+            "TSParameterProperty Identifier"(node) {
                 // just assume parameter properties are used
-                markVariableAsUsed(context, node.parameter.name);
-            },
-
-            FunctionDeclaration: markFunctionOptionsAsUsed,
-            FunctionExpression: markFunctionOptionsAsUsed,
-            ArrowFunctionExpression: markFunctionOptionsAsUsed,
-
-            CallExpression: markExpressionAsUsed,
-            NewExpression: markExpressionAsUsed,
-
-            Decorator: markDecoratorAsUsed,
-            TSInterfaceHeritage: markExtendedInterfaceAsUsed,
-
-            ClassDeclaration: markClassOptionsAsUsed,
-            ClassExpression: markClassOptionsAsUsed,
-
-            ObjectPattern(node) {
-                if (node.typeAnnotation) {
-                    markTypeAnnotationAsUsed(node.typeAnnotation);
-                }
-            },
-
-            MethodDefinition(node) {
-                if (node.decorators) {
-                    node.decorators.forEach(markDecoratorAsUsed);
-                }
+                context.markVariableAsUsed(node.name);
             },
         };
     },

--- a/lib/rules/type-annotation-spacing.js
+++ b/lib/rules/type-annotation-spacing.js
@@ -157,38 +157,13 @@ module.exports = {
             }
         }
 
-        /**
-         * Checks a function node for proper return type spacing.
-         * @param {ASTNode} node The node representing a function.
-         * @returns {void}
-         * @private
-         */
-        function checkFunctionReturnTypeSpacing(node) {
-            if (node.returnType) {
-                checkTypeAnnotationSpacing(
-                    node.returnType.typeAnnotation || node.returnType
-                );
-            }
-        }
-
         //----------------------------------------------------------------------
         // Public
         //----------------------------------------------------------------------
         return {
-            Identifier(node) {
-                if (node.typeAnnotation) {
-                    checkTypeAnnotationSpacing(
-                        node.typeAnnotation.typeAnnotation ||
-                            node.typeAnnotation
-                    );
-                }
-            },
             TSTypeAnnotation(node) {
                 checkTypeAnnotationSpacing(node.typeAnnotation);
             },
-            FunctionDeclaration: checkFunctionReturnTypeSpacing,
-            FunctionExpression: checkFunctionReturnTypeSpacing,
-            ArrowFunctionExpression: checkFunctionReturnTypeSpacing,
         };
     },
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "requireindex": "~1.2.0",
-    "typescript-eslint-parser": "^17.0.1"
+    "typescript-eslint-parser": "21.0.2"
   },
   "devDependencies": {
     "eslint": "^5.9.0",
@@ -35,7 +35,7 @@
     "lint-staged": "^8.1.0",
     "mocha": "^5.2.0",
     "prettier-eslint-cli": "^4.7.1",
-    "typescript": "~2.9"
+    "typescript": "~3.1.1"
   },
   "peerDependencies": {
     "eslint": ">=4.13.1 < 6"

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Check internal rule
+ * @author Armano <https://github.com/armano2>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("eslint/lib/rules/indent"),
+    RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: "module",
+        ecmaFeatures: {},
+    },
+    parser: "typescript-eslint-parser",
+});
+
+ruleTester.run("indent", rule, {
+    valid: [
+        `
+@Component({
+    components: {
+        ErrorPage: () => import('@/components/ErrorPage.vue'),
+    },
+    head: {
+        titleTemplate(title) {
+            if (title) {
+                return \`test\`
+            }
+            return 'Title'
+        },
+        htmlAttrs: {
+            lang: 'en',
+        },
+        meta: [
+            { charset: 'utf-8' },
+            { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+        ],
+    },
+})
+export default class App extends Vue 
+{
+    get error() 
+    {
+        return this.$store.state.errorHandler.error
+    }
+}
+        `,
+        // https://github.com/eslint/typescript-eslint-parser/issues/474
+        `
+/**
+ * @param {string} name
+ * @param {number} age
+ * @returns {string}
+ */
+function foo(name: string, age: number): string {}
+        `,
+        `
+const firebaseApp = firebase.apps.length
+    ? firebase.app()
+    : firebase.initializeApp({
+        apiKey: __FIREBASE_API_KEY__,
+        authDomain: __FIREBASE_AUTH_DOMAIN__,
+        databaseURL: __FIREBASE_DATABASE_URL__,
+        projectId: __FIREBASE_PROJECT_ID__,
+        storageBucket: __FIREBASE_STORAGE_BUCKET__,
+        messagingSenderId: __FIREBASE_MESSAGING_SENDER_ID__,
+    })
+        `,
+    ],
+    invalid: [],
+});

--- a/tests/lib/rules/no-explicit-any.js
+++ b/tests/lib/rules/no-explicit-any.js
@@ -604,5 +604,75 @@ type obj = {
                 },
             ],
         },
+        {
+            code: `class Foo<t = any> extends Bar<any> {}`,
+            errors: [
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 15,
+                },
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 32,
+                },
+            ],
+        },
+        {
+            code: `abstract class Foo<t = any> extends Bar<any> {}`,
+            errors: [
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 24,
+                },
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 41,
+                },
+            ],
+        },
+        {
+            code: `abstract class Foo<t = any> implements Bar<any>, Baz<any> {}`,
+            errors: [
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 24,
+                },
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 44,
+                },
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 54,
+                },
+            ],
+        },
+        {
+            code: `new Foo<any>()`,
+            errors: [
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 9,
+                },
+            ],
+        },
+        {
+            code: `Foo<any>()`,
+            errors: [
+                {
+                    message: "Unexpected any. Specify a different type.",
+                    line: 1,
+                    column: 5,
+                },
+            ],
+        },
     ],
 });

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Check internal rule
+ * @author Armano <https://github.com/armano2>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("eslint/lib/rules/no-undef"),
+    RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: "module",
+        ecmaFeatures: {},
+    },
+    parser: "typescript-eslint-parser",
+});
+
+ruleTester.run("no-undef", rule, {
+    valid: [
+        `
+import Beemo from './Beemo';
+import Driver from './Driver';
+import Script from './Script';
+import Context from './contexts/Context';
+import DriverContext from './contexts/DriverContext';
+import ScriptContext from './contexts/ScriptContext';
+
+export { Context, Driver, DriverContext, Script, ScriptContext };
+
+export * from './constants';
+
+export * from './types';
+
+export default Beemo;
+        `,
+    ],
+    invalid: [],
+});

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -238,6 +238,20 @@ new Foo();
 		`,
         `
 import { Nullable } from 'nullable';
+import { SomeOther } from 'some';
+import { Component } from 'react';
+class Foo implements Component<Nullable<SomeOther>, {}>{}
+new Foo();
+		`,
+        `
+import { Nullable } from 'nullable';
+import { SomeOther } from 'some';
+import { Component, Component2 } from 'react';
+class Foo implements Component<Nullable<SomeOther>, {}>, Component2{}
+new Foo();
+		`,
+        `
+import { Nullable } from 'nullable';
 import { Another } from 'some';
 class A {
     do = (a: Nullable<Another>) => { console.log(a); }
@@ -402,7 +416,7 @@ export const a: A<SomeOther> = {
     foo: "bar"
 };
         `,
-        // https://github.com/nzakas/eslint-plugin-typescript/issues/150
+        // https://github.com/bradzacher/eslint-plugin-typescript/issues/150
         `
 export class App {
     constructor(private logger: Logger) {
@@ -441,6 +455,51 @@ export class App {
         console.log(this.logger);
     }
 }
+        `,
+        // https://github.com/bradzacher/eslint-plugin-typescript/issues/126
+        `
+import { Component, Vue } from 'vue-property-decorator';
+import HelloWorld from './components/HelloWorld.vue';
+
+@Component({
+  components: {
+    HelloWorld
+  }
+})
+export default class App extends Vue {}
+        `,
+        // https://github.com/bradzacher/eslint-plugin-typescript/issues/189
+        `
+import firebase, {User} from 'firebase/app'
+// initialize firebase project
+firebase.initializeApp({
+})
+export function authenticated(cb: (user: User | null) => void): void {
+  firebase.auth().onAuthStateChanged(user => cb(user))
+}
+        `,
+        // https://github.com/bradzacher/eslint-plugin-typescript/issues/33
+        `
+import { Foo } from './types';
+export class Bar<T extends Foo> {}
+        `,
+        `
+import webpack from 'webpack';
+export default function webpackLoader(this: webpack.loader.LoaderContext) {}
+        `,
+        `
+import execa, { Options as ExecaOptions } from 'execa';
+export function foo(options: ExecaOptions): execa {
+    options()
+}
+        `,
+        `
+import { Foo, Bar } from './types';
+export class Baz<F = Foo & Bar> {}
+        `,
+        `
+// warning 'B' is defined but never used
+export const a: Array<{b: B}> = []
         `,
     ],
 
@@ -620,6 +679,24 @@ import { Nullable } from 'nullable';
 import { SomeOther } from 'some';
 import { Another } from 'some';
 class A extends Nullable {
+    other: Nullable<Another>;
+}
+new A();
+            `,
+            errors: [
+                {
+                    message: "'SomeOther' is defined but never used.",
+                    line: 3,
+                    column: 10,
+                },
+            ],
+        },
+        {
+            code: `
+import { Nullable } from 'nullable';
+import { SomeOther } from 'some';
+import { Another } from 'some';
+abstract class A extends Nullable {
     other: Nullable<Another>;
 }
 new A();

--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -3381,6 +3381,71 @@ type Foo = {
                 },
             ],
         },
+        // https://github.com/bradzacher/eslint-plugin-typescript/issues/152
+        {
+            code: `
+                class Some {
+                    a : {some: string, other: {more: number}};
+                    someMethod : (args : {some: string, other: {more: number}}) => void;
+                    doSomething(args : {some: string, other: {more: number}}) : void {}
+                }
+            `,
+            options: [{ after: true, before: true }],
+            output: `
+                class Some {
+                    a : {some : string, other : {more : number}};
+                    someMethod : (args : {some : string, other : {more : number}}) => void;
+                    doSomething(args : {some : string, other : {more : number}}) : void {}
+                }
+            `,
+            errors: [
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 3,
+                    column: 30,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 3,
+                    column: 45,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 3,
+                    column: 52,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 4,
+                    column: 47,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 4,
+                    column: 62,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 4,
+                    column: 69,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 5,
+                    column: 45,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 5,
+                    column: 60,
+                },
+                {
+                    message: `Expected a space before the ':'`,
+                    line: 5,
+                    column: 67,
+                },
+            ],
+        },
     ],
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,7 @@ lodash.unescape@4.0.1:
 lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -2534,6 +2535,15 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript-eslint-parser@21.0.2:
+  version "21.0.2"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz#270af10e4724528677fbcf34ea495284bec3a894"
+  integrity sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==
+  dependencies:
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+    typescript-estree "5.3.0"
+
 typescript-eslint-parser@^16.0.0:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz#b40681c7043b222b9772748b700a000b241c031b"
@@ -2541,16 +2551,22 @@ typescript-eslint-parser@^16.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript-eslint-parser@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-17.0.1.tgz#ddc681a3afa51a9baa6746a001eb5f29fb1365d3"
+typescript-estree@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/typescript-estree/-/typescript-estree-5.3.0.tgz#fb6c977b5e21073eb16cbdc0338a7f752da99ff5"
+  integrity sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^2.5.1, typescript@~2.9:
+typescript@^2.5.1:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+
+typescript@~3.1.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
To make it work this PR has to be merged due to bug in visitor-tree

- [x] ~~https://github.com/eslint/typescript-eslint-parser/pull/554~~
- [x] ~~https://github.com/eslint/typescript-eslint-parser/pull/560~~
- [x] ~~https://github.com/eslint/typescript-eslint-parser/pull/561~~
- [x] ~~https://github.com/eslint/typescript-eslint-parser/pull/562~~
- [x] ~~https://github.com/eslint/typescript-eslint-parser/pull/565~~
- [x] ~~https://github.com/eslint/typescript-eslint-parser/pull/571~~
- [x] ~~New release of [`typescript-eslint-parser`](https://github.com/eslint/typescript-eslint-parser)~~

unblocks #117, #181 PR

fixes: #152, #155, #126, #164, #166, #171, #193, #189, #143, #33