### PR TITLE
[FIX] [no-use-before-define] fix top level scope handling

### DIFF
--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -43,7 +43,7 @@ function parseOptions(options) {
  * @param {Scope} scope - a scope to check
  * @returns {boolean} `true` if the scope is toplevel
  */
-function isToplevelScope(scope) {
+function isTopLevelScope(scope) {
     return scope.type === "module" || scope.type === "global";
 }
 
@@ -71,7 +71,7 @@ function isOuterClass(variable, reference) {
 
     if (variable.scope.variableScope === reference.from.variableScope) {
         // allow the same scope only if it's the top level global/module scope
-        if (!isToplevelScope(variable.scope.variableScope)) {
+        if (!isTopLevelScope(variable.scope.variableScope)) {
             return false;
         }
     }
@@ -92,7 +92,7 @@ function isOuterVariable(variable, reference) {
 
     if (variable.scope.variableScope === reference.from.variableScope) {
         // allow the same scope only if it's the top level global/module scope
-        if (!isToplevelScope(variable.scope.variableScope)) {
+        if (!isTopLevelScope(variable.scope.variableScope)) {
             return false;
         }
     }

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -40,6 +40,14 @@ function parseOptions(options) {
 }
 
 /**
+ * @param {Scope} scope - a scope to check
+ * @returns {boolean} `true` if the scope is toplevel
+ */
+function isToplevelScope(scope) {
+    return scope.type === "module" || scope.type === "global";
+}
+
+/**
  * Checks whether or not a given variable is a function declaration.
  *
  * @param {eslint-scope.Variable} variable - A variable to check.
@@ -57,10 +65,18 @@ function isFunction(variable) {
  * @returns {boolean} `true` if the variable is a class declaration.
  */
 function isOuterClass(variable, reference) {
-    return (
-        variable.defs[0].type === "ClassName" &&
-        variable.scope.variableScope !== reference.from.variableScope
-    );
+    if (variable.defs[0].type !== "ClassName") {
+        return false;
+    }
+
+    if (variable.scope.variableScope === reference.from.variableScope) {
+        // allow the same scope only if it's the top level global/module scope
+        if (!isToplevelScope(variable.scope.variableScope)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**
@@ -70,10 +86,18 @@ function isOuterClass(variable, reference) {
  * @returns {boolean} `true` if the variable is a variable declaration.
  */
 function isOuterVariable(variable, reference) {
-    return (
-        variable.defs[0].type === "Variable" &&
-        variable.scope.variableScope !== reference.from.variableScope
-    );
+    if (variable.defs[0].type !== "Variable") {
+        return false;
+    }
+
+    if (variable.scope.variableScope === reference.from.variableScope) {
+        // allow the same scope only if it's the top level global/module scope
+        if (!isToplevelScope(variable.scope.variableScope)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -178,6 +178,26 @@ type Foo = string | number
             `,
             options: [{ typedefs: false }],
             parser: "typescript-eslint-parser"
+        },
+
+        // test for https://github.com/bradzacher/eslint-plugin-typescript/issues/142
+        {
+            code: `
+var alias = Test;
+
+class Test {}
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ classes: false }]
+        },
+        {
+            code: `
+var alias = Test;
+
+export class Test {}
+            `,
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            options: [{ classes: false }]
         }
     ],
     invalid: [
@@ -509,20 +529,6 @@ var a=function() {};
         {
             code: `
 new A();
-class A {};
-            `,
-            options: [{ functions: false, classes: false }],
-            parserOptions: { ecmaVersion: 6 },
-            errors: [
-                {
-                    message: "'A' was used before it was defined.",
-                    type: "Identifier"
-                }
-            ]
-        },
-        {
-            code: `
-new A();
 var A = class {};
             `,
             options: [{ classes: false }],
@@ -685,19 +691,6 @@ var bar;
             errors: [
                 {
                     message: "'bar' was used before it was defined.",
-                    type: "Identifier"
-                }
-            ]
-        },
-        {
-            code: `
-foo;
-var foo;
-            `,
-            options: [{ variables: false }],
-            errors: [
-                {
-                    message: "'foo' was used before it was defined.",
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
Fixes #142

The problem was it was failing to accept the case when both the def and the var were in the top-level global/module scope