### PR TITLE
Fix class-name-casing for TSAbstractClassDeclaration

### DIFF
--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -54,6 +54,9 @@ module.exports = {
                 case "ClassExpression":
                     friendlyName = "Class";
                     break;
+                case "TSAbstractClassDeclaration":
+                    friendlyName = "Abstract class";
+                    break;
                 case "TSInterfaceDeclaration":
                     friendlyName = "Interface";
                     break;
@@ -72,21 +75,19 @@ module.exports = {
         //----------------------------------------------------------------------
 
         return {
-            "ClassDeclaration, TSInterfaceDeclaration"(node) {
+            "ClassDeclaration, TSInterfaceDeclaration, TSAbstractClassDeclaration, ClassExpression"(
+                node
+            ) {
                 // class expressions (i.e. export default class {}) are OK
                 if (node.id && !isPascalCase(node.id.name)) {
                     report(node);
                 }
             },
-            VariableDeclarator(node) {
-                if (node.init && node.init.type === "ClassExpression") {
-                    const id = node.id;
+            "VariableDeclarator[init.type='ClassExpression']"(node) {
+                const id = node.id;
 
-                    if (node.init.id && !isPascalCase(node.init.id.name)) {
-                        report(node.init);
-                    } else if (id && !isPascalCase(id.name)) {
-                        report(node.init, id);
-                    }
+                if (id && !node.init.id && !isPascalCase(id.name)) {
+                    report(node.init, id);
                 }
             },
         };

--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces PascalCased class and interface names.
  * @author Jed Fox
+ * @author Armano <https://github.com/armano2>
  */
 "use strict";
 

--- a/tests/lib/rules/class-name-casing.js
+++ b/tests/lib/rules/class-name-casing.js
@@ -31,6 +31,8 @@ ruleTester.run("class-name-casing", rule, {
         "var Foo = class {};",
         "interface SomeInterface {}",
         "class ClassNameWithDigit2 {}",
+        "abstract class ClassNameWithDigit2 {}",
+        "var ba_zz = class Foo {};",
     ],
 
     invalid: [
@@ -66,6 +68,16 @@ ruleTester.run("class-name-casing", rule, {
             ],
         },
         {
+            code: "const foo = class {};",
+            errors: [
+                {
+                    message: "Class 'foo' must be PascalCased",
+                    line: 1,
+                    column: 7,
+                },
+            ],
+        },
+        {
             code: "var bar = class invalidName {}",
             errors: [
                 {
@@ -82,6 +94,27 @@ ruleTester.run("class-name-casing", rule, {
                     message: "Interface 'someInterface' must be PascalCased",
                     line: 1,
                     column: 11,
+                },
+            ],
+        },
+        {
+            code: "abstract class invalidClassName {}",
+            errors: [
+                {
+                    message:
+                        "Abstract class 'invalidClassName' must be PascalCased",
+                    line: 1,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: "declare class invalidClassName {}",
+            errors: [
+                {
+                    message: "Class 'invalidClassName' must be PascalCased",
+                    line: 1,
+                    column: 15,
                 },
             ],
         },

--- a/tests/lib/rules/class-name-casing.js
+++ b/tests/lib/rules/class-name-casing.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces PascalCased class and interface names.
  * @author Jed Fox
+ * @author Armano <https://github.com/armano2>
  */
 "use strict";
 


### PR DESCRIPTION
This PR adds support for TSAbstractClassDeclaration in `class-name-casing` and fixes issue with:
```ts
var ba_zz = class Foo {};
```

ba_zz was reported as not PascalCase even if class name is Foo 