### PR TITLE
[DOCS] Add contributing to README, and disable vscode autoformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 end_of_line = lf
 insert_final_newline = true
+
+# yarn / npm uses 2 spaces when it dumps the file after a change
+[package.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ versions.json
 yarn.lock
 /.vscode/*
 !/.vscode/settings.json
+!/.vscode/extensions.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ node_js:
     - "8"
     - "10"
     - "11"
+install: yarn
+script:
+    - yarn lint
+    - yarn format-check
+    - yarn docs:check
+    - yarn test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,11 @@
 {
     "recommendations": [
         "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig"
+    ],
+    "unwantedRecommendations": [
+        "hookyqr.beautify",
+        "dbaeumer.jshint"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    // Format a file on save. A formatter must be available, the file must not be auto-saved, and editor must not be shutting down.
-    "editor.formatOnSave": true,
-
     // An array of languages where Emmet abbreviations should not be expanded.
     "emmet.excludeLanguages": [
         "markdown",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Commenting and Discussing
+
+***Don't be a douche.***
+Consider the following when commenting:
+
+- Everyone is a human (except for the bots).
+- Everyone is freely providing their time for this project.
+- Everyone wants to build the best tool.
+
+## PR Requirements
+
+For a PR to be merged, you must pass the following checks:
+
+- there must be no lint errors - `yarn lint`
+- the code must be formatted - `yarn format`
+- your documentation must be up to date - `yarn docs-check`
+- all tests must pass - `yarn test`
+
+There is a commit hook which will help you follow this.
+Travis will also automatically run these checks when you submit your PR (and will block us merging until you fix it).
+
+## Adding/Changing a rule
+
+When adding or changing a rule, you must:
+
+- Ensure your feature / bug has an issue behind it.
+  - This just makes it easier for people to find information in future, because PRs aren't included in the default issue search.
+- Ensure your changes are covered by tests.
+  - There's no hard and fast rule for how much testing is required, but try to cover as many bases as you can.
+- Ensure your changes are documented in the `docs` folder. We're working to standardise how we document rules, but your docs should:
+  - describe what the rule does, and why you might enable it.
+  - (if any) outline the settings; how to configure them and what each one does
+  - have clear examples of valid and invalid code when using the rule. Bonus points for extra cases showing what each setting does.
+
+When adding a rule, you must also add a link to the rule in the README.md.
+
+## Submitting Issues
+
+- If your issue relates to a rule, start your title with the rule name:
+  - `[no-unused-vars] False positive when fooing the bar`
+- Search for the issue before you ask; we try hard to ensure it's easy to find existing issues.
+- Follow the template.
+  - We've built it to reduce the chance of us going back to ask you for things.
+  - Don't be lazy and skip parts of it; we'll just ask you for that information anyway, so it'll only delay the process.

--- a/README.md
+++ b/README.md
@@ -71,3 +71,34 @@ This guarantees 100% compatibility between the plugin and the parser.
 * [`typescript/prefer-namespace-keyword`](./docs/rules/prefer-namespace-keyword.md) — Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules. (`no-internal-module` from TSLint)
 * [`typescript/type-annotation-spacing`](./docs/rules/type-annotation-spacing.md) — Require consistent spacing around type annotations
 <!-- end rule list -->
+
+## Contributing
+
+If you're using vscode, we recommend you install both the Pretier and ESLint extensions, and turn on format on save.
+```CJSON
+{
+    // Format a file on save. A formatter must be available, the file must not be auto-saved, and editor must not be shutting down.
+    "[javascript]": {
+        "editor.formatOnSave": true
+    },
+}
+```
+
+For a PR to be merged, all tests must pass, the must be no lint errors, and the code must be formatted.
+- `yarn test`
+- `yarn lint`
+- `yarn format`
+There is a commit hook which will will help you follow this.
+Note that travis will also automatically run the checks when you submit your PR.
+
+When adding or updating a rule, you must:
+- Ensure your feature / bug has an issue behind it.
+  - This just makes it easier for people to find information in future, because PRs aren't included in the default issue search.
+- Ensure your changes are covered by tests.
+  - There's no hard and fast rule for how much testing is required, but try to cover as many bases as you can.
+- Ensure your changes are documented in the `docs` folder. We're working to standardise how we document rules, but your docs should:
+  - describe what the rule does, and why you might enable it.
+  - (if any) outline the settings; how to configure them and what each one does
+  - have clear examples of valid and invalid code when using the rule. Bonus points for extra cases showing what each setting does.
+
+When adding a rule, you must also add a link to the rule in the README.md.

--- a/README.md
+++ b/README.md
@@ -71,24 +71,3 @@ This guarantees 100% compatibility between the plugin and the parser.
 * [`typescript/prefer-namespace-keyword`](./docs/rules/prefer-namespace-keyword.md) — Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules. (`no-internal-module` from TSLint)
 * [`typescript/type-annotation-spacing`](./docs/rules/type-annotation-spacing.md) — Require consistent spacing around type annotations
 <!-- end rule list -->
-
-## Contributing
-
-For a PR to be merged, all tests must pass, the must be no lint errors, and the code must be formatted.
-- `yarn test`
-- `yarn lint`
-- `yarn format`
-There is a commit hook which will will help you follow this.
-Note that travis will also automatically run the checks when you submit your PR.
-
-When adding or updating a rule, you must:
-- Ensure your feature / bug has an issue behind it.
-  - This just makes it easier for people to find information in future, because PRs aren't included in the default issue search.
-- Ensure your changes are covered by tests.
-  - There's no hard and fast rule for how much testing is required, but try to cover as many bases as you can.
-- Ensure your changes are documented in the `docs` folder. We're working to standardise how we document rules, but your docs should:
-  - describe what the rule does, and why you might enable it.
-  - (if any) outline the settings; how to configure them and what each one does
-  - have clear examples of valid and invalid code when using the rule. Bonus points for extra cases showing what each setting does.
-
-When adding a rule, you must also add a link to the rule in the README.md.

--- a/README.md
+++ b/README.md
@@ -74,16 +74,6 @@ This guarantees 100% compatibility between the plugin and the parser.
 
 ## Contributing
 
-If you're using vscode, we recommend you install both the Pretier and ESLint extensions, and turn on format on save.
-```CJSON
-{
-    // Format a file on save. A formatter must be available, the file must not be auto-saved, and editor must not be shutting down.
-    "[javascript]": {
-        "editor.formatOnSave": true
-    },
-}
-```
-
 For a PR to be merged, all tests must pass, the must be no lint errors, and the code must be formatted.
 - `yarn test`
 - `yarn lint`

--- a/package.json
+++ b/package.json
@@ -1,57 +1,57 @@
 {
-    "name": "eslint-plugin-typescript",
-    "version": "0.14.0",
-    "description": "TypeScript plugin for ESLint",
-    "keywords": [
-        "eslint",
-        "eslintplugin",
-        "eslint-plugin"
-    ],
-    "repository": "nzakas/eslint-plugin-typescript",
-    "author": "Nicholas C. Zakas",
-    "main": "lib/index.js",
-    "scripts": {
-        "lint": "eslint lib/ tests/",
-        "lint:fix": "eslint lib/ tests/ --fix",
-        "docs": "eslint-docs",
-        "docs:check": "eslint-docs check",
-        "format-no-write": "prettier-eslint lib/**/*.js tests/**/*.js --eslint-config-path=.eslintrc --eslint-ignore --prettier-ignore --eslint-path=node_modules/eslint --config=.prettierrc",
-        "format": "yarn format-no-write --write",
-        "format-check": "yarn format-no-write --list-different",
-        "mocha": "mocha tests --recursive --reporter=dot",
-        "pretest": "npm run lint",
-        "test": "mocha tests --recursive --reporter=dot",
-        "posttest": "npm run docs:check",
-        "precommit": "npm test && lint-staged"
-    },
-    "dependencies": {
-        "requireindex": "~1.2.0",
-        "typescript-eslint-parser": "^17.0.1"
-    },
-    "devDependencies": {
-        "eslint": "^5.9.0",
-        "eslint-config-eslint": "^5.0.1",
-        "eslint-config-prettier": "^3.3.0",
-        "eslint-docs": "^0.1.1",
-        "eslint-plugin-node": "^6.0.1",
-        "eslint-plugin-prettier": "^3.0.0",
-        "husky": "^1.2.0",
-        "lint-staged": "^8.1.0",
-        "mocha": "^5.2.0",
-        "prettier-eslint-cli": "^4.7.1",
-        "typescript": "~2.9"
-    },
-    "peerDependencies": {
-        "eslint": ">=4.13.1 < 6"
-    },
-    "lint-staged": {
-        "*.js": [
-            "yarn format",
-            "git add"
-        ]
-    },
-    "engines": {
-        "node": ">=6"
-    },
-    "license": "MIT"
+  "name": "eslint-plugin-typescript",
+  "version": "0.14.0",
+  "description": "TypeScript plugin for ESLint",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "repository": "nzakas/eslint-plugin-typescript",
+  "author": "Nicholas C. Zakas",
+  "main": "lib/index.js",
+  "scripts": {
+    "lint": "eslint lib/ tests/",
+    "lint:fix": "eslint lib/ tests/ --fix",
+    "docs": "eslint-docs",
+    "docs:check": "eslint-docs check",
+    "format-no-write": "prettier-eslint lib/**/*.js tests/**/*.js --eslint-config-path=.eslintrc --eslint-ignore --prettier-ignore --eslint-path=node_modules/eslint --config=.prettierrc",
+    "format": "yarn format-no-write --write",
+    "format-check": "yarn format-no-write --list-different",
+    "mocha": "mocha tests --recursive --reporter=dot",
+    "pretest": "npm run lint",
+    "test": "mocha tests --recursive --reporter=dot",
+    "posttest": "npm run docs:check",
+    "precommit": "npm test && lint-staged"
+  },
+  "dependencies": {
+    "requireindex": "~1.2.0",
+    "typescript-eslint-parser": "^17.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^5.9.0",
+    "eslint-config-eslint": "^5.0.1",
+    "eslint-config-prettier": "^3.3.0",
+    "eslint-docs": "^0.1.1",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-prettier": "^3.0.0",
+    "husky": "^1.2.0",
+    "lint-staged": "^8.1.0",
+    "mocha": "^5.2.0",
+    "prettier-eslint-cli": "^4.7.1",
+    "typescript": "~2.9"
+  },
+  "peerDependencies": {
+    "eslint": ">=4.13.1 < 6"
+  },
+  "lint-staged": {
+    "*.js": [
+      "yarn format",
+      "git add"
+    ]
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,8 @@
     "format-no-write": "prettier-eslint lib/**/*.js tests/**/*.js --eslint-config-path=.eslintrc --eslint-ignore --prettier-ignore --eslint-path=node_modules/eslint --config=.prettierrc",
     "format": "yarn format-no-write --write",
     "format-check": "yarn format-no-write --list-different",
-    "mocha": "mocha tests --recursive --reporter=dot",
-    "pretest": "npm run lint",
     "test": "mocha tests --recursive --reporter=dot",
-    "posttest": "npm run docs:check",
-    "precommit": "npm test && lint-staged"
+    "precommit": "yarn lint && yarn test && yarn docs:check && lint-staged"
   },
   "dependencies": {
     "requireindex": "~1.2.0",


### PR DESCRIPTION
The vscode autoformatter is completely at odds with prettier, so if you don't have the prettier extension installed, you end up with wild changes.

Additionally if you've got both the beautify and prettier extensions installed, it can cause some serious issues.

Forcing it to be on will probably cause a lot of headaches to anyone trying to contribute unless they get their environment setup perfectly (sorry @weirdpattern for earlier!!)