### PR TITLE
Remove extra step in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ You'll first need to install [ESLint](http://eslint.org):
 $ npm i eslint --save-dev
 ```
 
-Next, install `typescript-eslint-parser`:
-
-```
-$ npm install typescript-eslint-parser --save-dev
-```
-
 Last, install `eslint-plugin-typescript`:
 
 ```


### PR DESCRIPTION
This package now depends directly on typescript-eslint-parser, so no need to do that.