### PR TITLE
Fix issue with declare module without body in prefer-namespace-keyword

### DIFF
--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces the use of the keyword `namespace` over `module` to declare custom TypeScript modules.
  * @author Patricio Trevino
+ * @author Armano <https://github.com/armano2>
  */
 "use strict";
 
@@ -32,41 +33,27 @@ module.exports = {
         //----------------------------------------------------------------------
         return {
             TSModuleDeclaration(node) {
-                // Get tokens of the declaration header.
-                const firstToken = sourceCode.getFirstToken(node);
-                const tokens = [firstToken].concat(
-                    sourceCode.getTokensBetween(
-                        firstToken,
-                        sourceCode.getFirstToken(node.body)
-                    )
-                );
-
-                // Get 'module' token and the next one.
-                const moduleKeywordIndex = tokens.findIndex(
-                    t => t.type === "Identifier" && t.value === "module"
-                );
-                const moduleKeywordToken =
-                    moduleKeywordIndex === -1
-                        ? null
-                        : tokens[moduleKeywordIndex];
-                const moduleNameToken = tokens[moduleKeywordIndex + 1];
-
-                // Do nothing if the 'module' token was not found or the module name is a string.
-                if (!moduleKeywordToken || moduleNameToken.type === "String") {
+                // Do nothing if the name is a string.
+                if (!node.id || node.id.type === "Literal") {
                     return;
                 }
+                // Get tokens of the declaration header.
+                const moduleType = sourceCode.getTokenBefore(node.id);
 
-                context.report({
-                    node,
-                    message:
-                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
-                    fix(fixer) {
-                        return fixer.replaceText(
-                            moduleKeywordToken,
-                            "namespace"
-                        );
-                    },
-                });
+                if (
+                    moduleType &&
+                    moduleType.type === "Identifier" &&
+                    moduleType.value === "module"
+                ) {
+                    context.report({
+                        node,
+                        message:
+                            "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
+                        fix(fixer) {
+                            return fixer.replaceText(moduleType, "namespace");
+                        },
+                    });
+                }
             },
         };
     },

--- a/tests/lib/rules/prefer-namespace-keyword.js
+++ b/tests/lib/rules/prefer-namespace-keyword.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces the use of the keyword `namespace` over `module` to declare custom TypeScript modules.
  * @author Patricio Trevino
+ * @author Armano <https://github.com/armano2>
  */
 "use strict";
 
@@ -21,6 +22,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("prefer-namespace-keyword", rule, {
     valid: [
+        "declare module 'foo'",
         "declare module 'foo' { }",
         "namespace foo { }",
         "declare namespace foo { }",
@@ -29,6 +31,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
     invalid: [
         {
             code: "module foo { }",
+            output: "namespace foo { }",
             errors: [
                 {
                     message:
@@ -41,6 +44,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
         },
         {
             code: "declare module foo { }",
+            output: "declare namespace foo { }",
             errors: [
                 {
                     message:
@@ -57,22 +61,21 @@ declare module foo {
     declare module bar { }
 }
             `,
+            output: `
+declare namespace foo {
+    declare namespace bar { }
+}
+            `,
             errors: [
                 {
                     message:
                         "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
-                    output: "declare namespace foo { }",
                     row: 2,
                     column: 1,
                 },
                 {
                     message:
                         "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
-                    output: `
-declare namespace foo {
-    declare namespace bar { }
-}
-            `,
                     row: 3,
                     column: 5,
                 },

--- a/tests/lib/rules/prefer-namespace-keyword.js
+++ b/tests/lib/rules/prefer-namespace-keyword.js
@@ -36,7 +36,6 @@ ruleTester.run("prefer-namespace-keyword", rule, {
                 {
                     message:
                         "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
-                    output: "namespace foo { }",
                     row: 1,
                     column: 1,
                 },
@@ -49,7 +48,6 @@ ruleTester.run("prefer-namespace-keyword", rule, {
                 {
                     message:
                         "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
-                    output: "declare namespace foo { }",
                     row: 1,
                     column: 1,
                 },


### PR DESCRIPTION
This PR fixes issue #188

modules can have no body.

-----

there was so much weird logic with tokens there, and we don't need it, it should just take `id` and previous token (module/namespace)....