### PR TITLE
add missing parser.js to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,5 @@
 !lib/**/*
 !docs/**/*
 !package.json
+!parser.js
 !README.md


### PR DESCRIPTION
In current configuration of `.npmignore` there is ignored `parser.js` file so `parser: 'eslint-plugin-typescript/parser',` not working because is missing in package on npm registry.