### PR TITLE
[FEAT][BREAKING][1/2][member-delimiter-style] Better handling for single line

### DIFF
--- a/docs/rules/member-delimiter-style.md
+++ b/docs/rules/member-delimiter-style.md
@@ -5,12 +5,12 @@ Enforces a consistent member delimiter style in interfaces and type literals. Th
 ```ts
 interface Foo {
     name: string;
-    greet(): void; // last semicolon can be ignored
+    greet(): void;
 }
 
 type Bar = {
     name: string;
-    greet(): void; // last semicolon can be ignored
+    greet(): void;
 }
 ```
 
@@ -18,12 +18,12 @@ type Bar = {
 ```ts
 interface Foo {
     name: string,
-    greet(): void, // last comma can be ignored
+    greet(): void,
 }
 
 type Bar = {
     name: string,
-    greet(): void, // last comma can be ignored
+    greet(): void,
 }
 ```
 
@@ -40,7 +40,8 @@ type Bar = {
 }
 ```
 
-The rule also enforces the presence of the delimiter in the last member of the interface and/or type literal, allowing single line declarations to be ignored.
+The rule also enforces the presence (or absence) of the delimiter in the last member of the interface and/or type literal.
+Finally, this rule can enforce separate delimiter syntax for single line declarations.
 
 ## Rule Details
 
@@ -58,13 +59,16 @@ The rule can also take one or more of the following options:
 - `"delimiter": "none"`, use this to require a linebreak.
 - `"requireLast": true`, (default) use this to require a delimiter for all members of the interface and/or type literal.
 - `"requireLast": false`, use this to ignore the last member of the interface and/or type literal.
-- `"ignoreSingleLine": true`, (default) use this to override the `requireLast` in single line declarations.
-- `"ignoreSingleLine": false`, use this to enfore the `requireLast` in single line declarations.
+- `"singleLine": "semi"`, (default) use this to require a semicolon in single line declarations.
+- `"singleLine": "comma"`, use this to require a comma in single line declarations.
+- `"singleLine": "none"`, use this to require a linebreak (i.e. disallow mulit prop, single line declarations).
 - `"overrides"`, overrides the default options for **interfaces** and **type literals**.
+
+*Note that `delimiter` and `singleLine` are independent options - if you don't provide a value for either they will use their default option.*
 
 ### defaults
 Examples of **incorrect** code for this rule with the defaults
-`{ delimiter: "semi", requireLast: true, ignoreSingleLine: true }` or no option at all:
+`{ delimiter: "semi", requireLast: true, singleLine: "semi" }` or no option at all:
 ```ts
 // missing semicolon delimiter
 interface Foo {
@@ -101,17 +105,18 @@ type Baz = {
     name: string,
     greet(): string
 }
+
+// incorrect delimiter
+type FooBar = { name: string, greet(): string }
 ```
 
 Examples of **correct** code for this rule with the default
-`{ delimiter: "semi", requireLast: true, ignoreSingleLine: true }`:
+`{ delimiter: "semi", requireLast: true, singleLine: "semi" }`:
 ```ts
 interface Foo {
     name: string;
     greet(): string;
 }
-
-interface Foo { name: string }
 
 interface Foo { name: string; }
 
@@ -120,9 +125,9 @@ type Bar = {
     greet(): string;
 }
 
-type Bar = { name: string }
-
 type Bar = { name: string; }
+
+type FooBar = { name: string; greet(): string; }
 ```
 
 ### delimiter - semi
@@ -143,12 +148,11 @@ interface Bar {
 
 Examples of **correct** code for this rule with `{ delimiter: "semi" }`:
 ```ts
-// with requireLast = true/false
+// with requireLast = true
 interface Foo {
     name: string;
     greet(): string;
 }
-
 type Bar = {
     name: string;
     greet(): string;
@@ -159,7 +163,6 @@ interface Foo {
     name: string;
     greet(): string
 }
-
 type Bar = {
     name: string;
     greet(): string
@@ -184,12 +187,11 @@ interface Bar {
 
 Examples of **correct** code for this rule with `{ delimiter: "comma" }`:
 ```ts
-// with requireLast = true/false
+// with requireLast = true
 interface Foo {
     name: string,
     greet(): string,
 }
-
 type Bar = {
     name: string,
     greet(): string,
@@ -299,42 +301,72 @@ type Baz = {
 ```
 
 ### ignoreSingleLine
-Examples of **incorrect** code for this rule with `{ ignoreSingleLine: true }`:
+Examples of **incorrect** code for this rule with `{ singleLine: "semi" }`:
 ```ts
 // using incorrect delimiter
 interface Foo { name: string, }
+interface Foo { name: string, greet(): string, }
 
-// using incorrect delimiter
 type Bar = { name: string, }
+type Bar = { name: string, greet(): string, }
 ```
 
-Examples of **correct** code for this rule with `{ ignoreSingleLine: true }`:
-```ts
-// can have a delimiter or not
-interface Foo { name: string }
-
-interface Foo { name: string; }
-
-// can have a delimiter or not
-type Bar = { name: string }
-
-type Bar = { name: string; }
-```
-
-Examples of **incorrect** code for this rule with `{ ignoreSingleLine: false }`:
-```ts
-// missing delimiter
-interface Foo { name: string }
-
-// missing delimiter
-type Bar = { name: string }
-```
-
-Examples of **correct** code for this rule with `{ ignoreSingleLine: false }`:
+Examples of **correct** code for this rule with `{ singleLine: "semi" }`:
 ```ts
 interface Foo { name: string; }
+interface Foo { name: string; greet(): string; }
 
 type Bar = { name: string; }
+type Bar = { name: string; greet(): string; }
+```
+
+Examples of **incorrect** code for this rule with `{ singleLine: "comma" }`:
+```ts
+// using incorrect delimiter
+interface Foo { name: string; }
+interface Foo { name: string; greet(): string; }
+
+type Bar = { name: string; }
+type Bar = { name: string; greet(): string; }
+```
+
+Examples of **correct** code for this rule with `{ singleLine: "comma" }`:
+```ts
+interface Foo { name: string, }
+interface Foo { name: string, greet(): string, }
+
+type Bar = { name: string, }
+type Bar = { name: string, greet(): string, }
+```
+
+Examples of **incorrect** code for this rule with `{ singleLine: "none" }`:
+```ts
+// has a delimiter when it shouldn't
+interface Foo { name: string; }
+interface Foo { name: string; greet(): string; }
+interface Foo { name: string, }
+interface Foo { name: string, greet(): string, }
+
+type Bar = { name: string; }
+type Bar = { name: string; greet(): string; }
+type Bar = { name: string, }
+type Bar = { name: string, greet(): string, }
+```
+
+Examples of **correct** code for this rule with `{ singleLine: "none" }`:
+```ts
+interface Foo { name: string }
+type Bar = { name: string }
+
+// Note that there is no syntax-valid way to do types single-line without a delimiter
+interface Foo {
+    name: string
+    greet(): string
+}
+type Bar = {
+    name: string
+    greet(): string
+}
 ```
 
 ### overrides - interface

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -19,17 +19,6 @@ const definition = {
     additionalProperties: false,
 };
 
-const errorMessages = {
-    unexpected: {
-        comma: "Unexpected separator (,).",
-        semi: "Unexpected separator (;).",
-    },
-    expected: {
-        comma: "Expected a comma.",
-        semi: "Expected a semicolon.",
-    },
-};
-
 module.exports = {
     meta: {
         docs: {
@@ -40,6 +29,12 @@ module.exports = {
                 "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/member-delimiter-style.md",
         },
         fixable: "code",
+        messages: {
+            unexpectedComma: "Unexpected separator (,).",
+            unexpectedSemi: "Unexpected separator (;).",
+            expectedComma: "Expected a comma.",
+            expectedSemi: "Expected a semicolon.",
+        },
         schema: [
             {
                 type: "object",
@@ -104,25 +99,19 @@ module.exports = {
              * @returns {boolean} the resolved value
              */
             function getOption(type) {
-                // eslint-disable-next-line require-jsdoc
-                function getValue() {
-                    if (isSameLine) {
-                        return opts.singleLine === type;
-                    }
-                    return opts.delimiter === type;
-                }
-
-                if (isLast) {
-                    if (opts.requireLast) {
-                        return getValue();
-                    }
+                if (isLast && !opts.requireLast) {
+                    // only turn the option on if its expecting no delimiter for the last member
                     return type === "none";
                 }
-
-                return getValue();
+                if (isSameLine) {
+                    // use single line config
+                    return opts.singleLine === type;
+                }
+                // use normal config
+                return opts.delimiter === type;
             }
 
-            let message;
+            let messageId;
             let missingDelimiter = false;
             const lastToken = sourceCode.getLastToken(member, {
                 includeComments: false,
@@ -134,29 +123,29 @@ module.exports = {
 
             if (lastToken.value === ";") {
                 if (optsComma) {
-                    message = errorMessages.expected.comma;
+                    messageId = "expectedComma";
                 } else if (optsNone) {
                     missingDelimiter = true;
-                    message = errorMessages.unexpected.semi;
+                    messageId = "unexpectedSemi";
                 }
             } else if (lastToken.value === ",") {
                 if (optsSemi) {
-                    message = errorMessages.expected.semi;
+                    messageId = "expectedSemi";
                 } else if (optsNone) {
                     missingDelimiter = true;
-                    message = errorMessages.unexpected.comma;
+                    messageId = "unexpectedComma";
                 }
             } else {
                 if (optsSemi) {
                     missingDelimiter = true;
-                    message = errorMessages.expected.semi;
+                    messageId = "expectedSemi";
                 } else if (optsComma) {
                     missingDelimiter = true;
-                    message = errorMessages.expected.comma;
+                    messageId = "expectedComma";
                 }
             }
 
-            if (message) {
+            if (messageId) {
                 context.report({
                     node: lastToken,
                     loc: {
@@ -169,7 +158,7 @@ module.exports = {
                             column: lastToken.loc.end.column,
                         },
                     },
-                    message,
+                    messageId,
                     fix(fixer) {
                         if (optsNone) {
                             // remove the unneeded token
@@ -222,6 +211,4 @@ module.exports = {
             TSTypeLiteral: checkMemberSeparatorStyle,
         };
     },
-
-    errorMessages,
 };

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces a member delimiter style in interfaces and type literals.
  * @author Patricio Trevino
+ * @author Brad Zacher
  */
 "use strict";
 
@@ -13,9 +14,20 @@ const definition = {
     properties: {
         delimiter: { enum: ["none", "semi", "comma"] },
         requireLast: { type: "boolean" },
-        ignoreSingleLine: { type: "boolean" },
+        singleLine: { enum: ["none", "semi", "comma"] },
     },
     additionalProperties: false,
+};
+
+const errorMessages = {
+    unexpected: {
+        comma: "Unexpected separator (,).",
+        semi: "Unexpected separator (;).",
+    },
+    expected: {
+        comma: "Expected a comma.",
+        semi: "Expected a semicolon.",
+    },
 };
 
 module.exports = {
@@ -31,10 +43,7 @@ module.exports = {
         schema: [
             {
                 type: "object",
-                properties: {
-                    delimiter: { enum: ["none", "semi", "comma"] },
-                    requireLast: { type: "boolean" },
-                    ignoreSingleLine: { type: "boolean" },
+                properties: Object.assign({}, definition.properties, {
                     overrides: {
                         type: "object",
                         properties: {
@@ -43,7 +52,7 @@ module.exports = {
                         },
                         additionalProperties: false,
                     },
-                },
+                }),
                 additionalProperties: false,
             },
         ],
@@ -57,7 +66,7 @@ module.exports = {
         const defaults = {
             delimiter: "semi",
             requireLast: true,
-            ignoreSingleLine: true,
+            singleLine: "semi",
         };
 
         const interfaceOptions = Object.assign(
@@ -89,41 +98,61 @@ module.exports = {
          * @private
          */
         function checkLastToken(member, opts, isLast, isSameLine) {
+            /**
+             * Resolves the boolean value for the given setting enum value
+             * @param {"semi" | "comma" | "none"} type the option name
+             * @returns {boolean} the resolved value
+             */
+            function getOption(type) {
+                // eslint-disable-next-line require-jsdoc
+                function getValue() {
+                    if (isSameLine) {
+                        return opts.singleLine === type;
+                    }
+                    return opts.delimiter === type;
+                }
+
+                if (isLast) {
+                    if (opts.requireLast) {
+                        return getValue();
+                    }
+                    return type === "none";
+                }
+
+                return getValue();
+            }
+
             let message;
             let missingDelimiter = false;
             const lastToken = sourceCode.getLastToken(member, {
                 includeComments: false,
             });
 
-            if (lastToken.value === ";" && opts.delimiter !== "semi") {
-                message =
-                    opts.delimiter === "comma"
-                        ? "Expected a comma."
-                        : "Unexpected separator (;).";
-            } else if (lastToken.value === "," && opts.delimiter !== "comma") {
-                message =
-                    opts.delimiter === "semi"
-                        ? "Expected a semicolon."
-                        : "Unexpected separator (,).";
-            } else if (
-                lastToken.value !== ";" &&
-                lastToken.value !== "," &&
-                opts.delimiter !== "none"
-            ) {
-                let canOmit = isLast;
+            const optsSemi = getOption("semi");
+            const optsComma = getOption("comma");
+            const optsNone = getOption("none");
 
-                if (canOmit) {
-                    canOmit =
-                        !opts.requireLast ||
-                        (isSameLine && opts.ignoreSingleLine);
-                }
-
-                if (!canOmit) {
+            if (lastToken.value === ";") {
+                if (optsComma) {
+                    message = errorMessages.expected.comma;
+                } else if (optsNone) {
                     missingDelimiter = true;
-                    message =
-                        opts.delimiter === "semi"
-                            ? "Expected a semicolon."
-                            : "Expected a comma.";
+                    message = errorMessages.unexpected.semi;
+                }
+            } else if (lastToken.value === ",") {
+                if (optsSemi) {
+                    message = errorMessages.expected.semi;
+                } else if (optsNone) {
+                    missingDelimiter = true;
+                    message = errorMessages.unexpected.comma;
+                }
+            } else {
+                if (optsSemi) {
+                    missingDelimiter = true;
+                    message = errorMessages.expected.semi;
+                } else if (optsComma) {
+                    missingDelimiter = true;
+                    message = errorMessages.expected.comma;
                 }
             }
 
@@ -142,24 +171,16 @@ module.exports = {
                     },
                     message,
                     fix(fixer) {
-                        let token;
-
-                        if (opts.delimiter === "semi") {
-                            token = ";";
-                        } else if (opts.delimiter === "comma") {
-                            token = ",";
-                        } else {
+                        if (optsNone) {
                             // remove the unneeded token
                             return fixer.remove(lastToken);
                         }
 
+                        const token = optsSemi ? ";" : ",";
+
                         if (missingDelimiter) {
                             // add the missing delimiter
                             return fixer.insertTextAfter(lastToken, token);
-                        }
-
-                        if (isLast && !opts.requireLast) {
-                            return fixer.remove(lastToken);
                         }
 
                         // correct the current delimiter
@@ -176,14 +197,16 @@ module.exports = {
          * @private
          */
         function checkMemberSeparatorStyle(node) {
-            const isSingleLine = node.loc.start.line === node.loc.end.line;
             const isInterface = node.type === "TSInterfaceBody";
+
+            const isSingleLine = node.loc.start.line === node.loc.end.line;
+            const opts = isInterface ? interfaceOptions : typeLiteralOptions;
             const members = isInterface ? node.body : node.members;
 
             members.forEach((member, index) => {
                 checkLastToken(
                     member,
-                    isInterface ? interfaceOptions : typeLiteralOptions,
+                    opts,
                     index === members.length - 1,
                     isSingleLine
                 );
@@ -199,4 +222,6 @@ module.exports = {
             TSTypeLiteral: checkMemberSeparatorStyle,
         };
     },
+
+    errorMessages,
 };

--- a/tests/lib/rules/member-delimiter-style.js
+++ b/tests/lib/rules/member-delimiter-style.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces a member delimiter style in interfaces and type literals.
  * @author Patricio Trevino
+ * @author Brad Zacher
  */
 "use strict";
 
@@ -19,21 +20,25 @@ const ruleTester = new RuleTester({
     parser: "typescript-eslint-parser",
 });
 
+const errors = rule.errorMessages;
+
 ruleTester.run("member-delimiter-style", rule, {
     valid: [
-        `
-interface Foo {
-    name: string;
-    age: number;
-}
-        `,
         {
             code: `
 interface Foo {
     name: string;
     age: number;
 }
-            `,
+                `,
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+                    `,
             options: [{ delimiter: "semi", requireLast: true }],
         },
         {
@@ -42,7 +47,7 @@ interface Foo {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [{ delimiter: "semi" }],
         },
         {
@@ -51,16 +56,7 @@ interface Foo {
     name: string;
     age: number
 }
-            `,
-            options: [{ delimiter: "semi", requireLast: false }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [{ delimiter: "semi", requireLast: false }],
         },
         {
@@ -69,7 +65,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: true }],
         },
         {
@@ -78,7 +74,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma" }],
         },
         {
@@ -87,16 +83,7 @@ interface Foo {
     name: string,
     age: number
 }
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: false }],
         },
         {
@@ -105,7 +92,7 @@ interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: true }],
         },
         {
@@ -114,7 +101,7 @@ interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: false }],
         },
         {
@@ -123,7 +110,7 @@ interface Foo {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -143,7 +130,7 @@ interface Foo {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -157,27 +144,7 @@ interface Foo {
     name: string;
     age: number
 }
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: true,
-                    overrides: {
-                        interface: {
-                            delimiter: "semi",
-                            requireLast: false,
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -197,7 +164,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -217,7 +184,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -231,7 +198,7 @@ interface Foo {
     name: string,
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -248,27 +215,10 @@ interface Foo {
         {
             code: `
 interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    overrides: {
-                        interface: { delimiter: "comma", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -285,7 +235,7 @@ interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -302,7 +252,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
         },
         {
             code: `
@@ -310,7 +260,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [{ delimiter: "semi", requireLast: true }],
         },
         {
@@ -319,7 +269,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [{ delimiter: "semi" }],
         },
         {
@@ -328,16 +278,7 @@ type Foo = {
     name: string;
     age: number
 }
-            `,
-            options: [{ delimiter: "semi", requireLast: false }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [{ delimiter: "semi", requireLast: false }],
         },
         {
@@ -346,7 +287,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: true }],
         },
         {
@@ -355,7 +296,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma" }],
         },
         {
@@ -364,16 +305,7 @@ type Foo = {
     name: string,
     age: number
 }
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: false }],
         },
         {
@@ -382,7 +314,7 @@ type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: true }],
         },
         {
@@ -391,7 +323,7 @@ type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: false }],
         },
         {
@@ -400,7 +332,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -417,7 +349,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -431,24 +363,7 @@ type Foo = {
     name: string;
     age: number
 }
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: true,
-                    overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -465,7 +380,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -482,7 +397,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -496,7 +411,7 @@ type Foo = {
     name: string,
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -510,27 +425,10 @@ type Foo = {
         {
             code: `
 type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -547,7 +445,7 @@ type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -569,7 +467,7 @@ type Bar = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "none",
@@ -580,13 +478,14 @@ type Bar = {
                 },
             ],
         },
-        "interface Foo { [key: string]: any }",
-        "interface Foo { [key: string]: any; }",
+        {
+            code: "interface Foo { [key: string]: any; }",
+        },
         {
             code: "interface Foo { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -595,7 +494,7 @@ type Bar = {
             options: [
                 {
                     delimiter: "comma",
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -603,7 +502,7 @@ type Bar = {
             code: "interface Foo { [key: string]: any; }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -612,7 +511,7 @@ type Bar = {
             options: [
                 {
                     delimiter: "comma",
-                    ignoreSingleLine: false,
+                    singleLine: "comma",
                 },
             ],
         },
@@ -620,9 +519,9 @@ type Bar = {
             code: "interface Foo { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        interface: { ignoreSingleLine: true },
+                        interface: { singleLine: "none" },
                     },
                 },
             ],
@@ -632,7 +531,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -641,7 +540,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -650,20 +549,21 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        interface: { ignoreSingleLine: true },
+                        interface: { singleLine: "none" },
                     },
                 },
             ],
         },
-        "type Foo = { [key: string]: any }",
-        "type Foo = { [key: string]: any; }",
+        {
+            code: "type Foo = { [key: string]: any; }",
+        },
         {
             code: "type Foo = { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -671,7 +571,7 @@ type Bar = {
             code: "type Foo = { [key: string]: any; }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -679,9 +579,9 @@ type Bar = {
             code: "type Foo = { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        typeLiteral: { ignoreSingleLine: true },
+                        typeLiteral: { singleLine: "none" },
                     },
                 },
             ],
@@ -691,7 +591,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -700,7 +600,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -709,9 +609,46 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        typeLiteral: { ignoreSingleLine: true },
+                        typeLiteral: { singleLine: "none" },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+
+interface Bar { name: string }
+                `,
+            options: [
+                {
+                    delimiter: "semi",
+                    requireLast: true,
+                    singleLine: "none",
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+
+type Bar = { name: string }
+                `,
+            options: [
+                {
+                    delimiter: "semi",
+                    requireLast: true,
+                    singleLine: "semi",
+                    overrides: {
+                        typeLiteral: { singleLine: "none" },
                     },
                 },
             ],
@@ -733,12 +670,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -760,12 +697,12 @@ interface Foo {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -787,12 +724,12 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -814,7 +751,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
@@ -836,7 +773,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -858,12 +795,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -885,12 +822,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -912,7 +849,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -934,12 +871,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -961,12 +898,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -988,7 +925,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1010,12 +947,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1037,12 +974,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1064,12 +1001,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1091,7 +1028,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -1113,7 +1050,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1135,12 +1072,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1162,12 +1099,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1189,7 +1126,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1211,7 +1148,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1238,12 +1175,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1273,12 +1210,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1308,7 +1245,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1335,12 +1272,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1370,12 +1307,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1405,7 +1342,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -1432,12 +1369,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1467,12 +1404,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1502,7 +1439,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1532,12 +1469,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1564,12 +1501,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1599,12 +1536,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1634,7 +1571,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -1664,7 +1601,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1691,12 +1628,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1726,12 +1663,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1761,7 +1698,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1791,7 +1728,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1812,12 +1749,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1839,12 +1776,12 @@ type Foo = {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1866,12 +1803,12 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1893,7 +1830,7 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1915,12 +1852,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1942,12 +1879,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1969,7 +1906,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -1991,12 +1928,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2018,12 +1955,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2045,7 +1982,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2067,12 +2004,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2094,12 +2031,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2121,12 +2058,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2148,7 +2085,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -2170,7 +2107,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2192,12 +2129,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2219,12 +2156,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2246,7 +2183,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2268,7 +2205,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2295,12 +2232,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -2330,12 +2267,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -2365,7 +2302,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -2392,12 +2329,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -2427,12 +2364,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -2462,7 +2399,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -2489,12 +2426,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2524,12 +2461,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2559,7 +2496,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2589,12 +2526,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2621,12 +2558,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2656,12 +2593,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2691,7 +2628,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -2721,7 +2658,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2748,12 +2685,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2783,12 +2720,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2818,7 +2755,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2848,7 +2785,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2889,22 +2826,22 @@ type Bar = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 8,
                     column: 18,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 9,
                     column: 17,
                 },
@@ -2923,7 +2860,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -2940,10 +2877,10 @@ interface Foo {
     [key: string]: any;
 }
             `,
-            options: [{ ignoreSingleLine: true }],
+            options: [{ singleLine: "none" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -2952,10 +2889,10 @@ interface Foo {
         {
             code: "interface Foo { [key: string]: any }",
             output: "interface Foo { [key: string]: any; }",
-            options: [{ ignoreSingleLine: false }],
+            options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 35,
                 },
@@ -2967,12 +2904,12 @@ interface Foo {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 35,
                 },
@@ -2984,15 +2921,15 @@ interface Foo {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                     overrides: {
-                        interface: { ignoreSingleLine: false },
+                        interface: { singleLine: "semi" },
                     },
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 35,
                 },
@@ -3011,7 +2948,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -3028,10 +2965,10 @@ type Foo = {
     [key: string]: any;
 }
             `,
-            options: [{ ignoreSingleLine: true }],
+            options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -3040,10 +2977,10 @@ type Foo = {
         {
             code: "type Foo = { [key: string]: any }",
             output: "type Foo = { [key: string]: any; }",
-            options: [{ ignoreSingleLine: false }],
+            options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 32,
                 },
@@ -3055,12 +2992,12 @@ type Foo = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 32,
                 },
@@ -3072,15 +3009,118 @@ type Foo = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                     overrides: {
-                        typeLiteral: { ignoreSingleLine: false },
+                        typeLiteral: { singleLine: "semi" },
                     },
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
+                    line: 1,
+                    column: 32,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            options: [{ delimiter: "semi", requireLast: false }],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    delimiter: "comma",
+                    requireLast: true,
+                    overrides: {
+                        interface: {
+                            delimiter: "semi",
+                            requireLast: false,
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: "interface Foo { [key: string]: any }",
+            errors: [
+                {
+                    message: errors.expected.semi,
+                    line: 1,
+                    column: 35,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            options: [{ delimiter: "semi", requireLast: false }],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    delimiter: "comma",
+                    requireLast: true,
+                    overrides: {
+                        typeLiteral: { delimiter: "semi", requireLast: false },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: "type Foo = { [key: string]: any }",
+            errors: [
+                {
+                    message: errors.expected.semi,
                     line: 1,
                     column: 32,
                 },

--- a/tests/lib/rules/member-delimiter-style.js
+++ b/tests/lib/rules/member-delimiter-style.js
@@ -20,8 +20,6 @@ const ruleTester = new RuleTester({
     parser: "typescript-eslint-parser",
 });
 
-const errors = rule.errorMessages;
-
 ruleTester.run("member-delimiter-style", rule, {
     valid: [
         {
@@ -670,12 +668,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -697,12 +695,12 @@ interface Foo {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -724,12 +722,12 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -751,7 +749,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
@@ -773,7 +771,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -795,12 +793,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -822,12 +820,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -849,7 +847,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -871,12 +869,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -898,12 +896,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -925,7 +923,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -947,12 +945,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -974,12 +972,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1001,12 +999,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1028,7 +1026,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -1050,7 +1048,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1072,12 +1070,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1099,12 +1097,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1126,7 +1124,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -1148,7 +1146,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1175,12 +1173,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1210,12 +1208,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1245,7 +1243,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1272,12 +1270,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1307,12 +1305,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1342,7 +1340,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -1369,12 +1367,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1404,12 +1402,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1439,7 +1437,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -1469,12 +1467,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1501,12 +1499,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1536,12 +1534,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1571,7 +1569,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -1601,7 +1599,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1628,12 +1626,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1663,12 +1661,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1698,7 +1696,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -1728,7 +1726,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1749,12 +1747,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1776,12 +1774,12 @@ type Foo = {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1803,12 +1801,12 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1830,7 +1828,7 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1852,12 +1850,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1879,12 +1877,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1906,7 +1904,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -1928,12 +1926,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1955,12 +1953,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1982,7 +1980,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2004,12 +2002,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2031,12 +2029,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2058,12 +2056,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2085,7 +2083,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -2107,7 +2105,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2129,12 +2127,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2156,12 +2154,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2183,7 +2181,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2205,7 +2203,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2232,12 +2230,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -2267,12 +2265,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -2302,7 +2300,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -2329,12 +2327,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -2364,12 +2362,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -2399,7 +2397,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -2426,12 +2424,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2461,12 +2459,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2496,7 +2494,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2526,12 +2524,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2558,12 +2556,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2593,12 +2591,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2628,7 +2626,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -2658,7 +2656,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2685,12 +2683,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2720,12 +2718,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2755,7 +2753,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2785,7 +2783,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2826,22 +2824,22 @@ type Bar = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 8,
                     column: 18,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 9,
                     column: 17,
                 },
@@ -2860,7 +2858,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2880,7 +2878,7 @@ interface Foo {
             options: [{ singleLine: "none" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2892,7 +2890,7 @@ interface Foo {
             options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -2909,7 +2907,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -2929,7 +2927,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -2948,7 +2946,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2968,7 +2966,7 @@ type Foo = {
             options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2980,7 +2978,7 @@ type Foo = {
             options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },
@@ -2997,7 +2995,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },
@@ -3017,7 +3015,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },
@@ -3033,7 +3031,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3060,7 +3058,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3070,7 +3068,7 @@ interface Foo {
             code: "interface Foo { [key: string]: any }",
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -3086,7 +3084,7 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3110,7 +3108,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3120,7 +3118,7 @@ type Foo = {
             code: "type Foo = { [key: string]: any }",
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },


### PR DESCRIPTION
This PR adds better handling for single line delimiters, and better enforces the `requrieLast` option.

Fixes #92

## Single line delimiters

Previously single line delimiters were either checked or not. This meant that if you used
```
{
    delimiter: "none",
    ignoreSingleLine: false,
}
```
then the fixer would break your code by removing the delimiter from single line statements i.e.:
```TS
interface Foo { bar: string, baz: number }
// fixed to this broken line
interface Foo { bar: string baz: number }
```

### Breaking change:
- Removed option `ignoreSingleLine`
- Added option `singleLine: "none" | "semi" | "comma"`

`singleLine` works the same as `delimiter`, except for single line statements only.

## Stricter `requireLast`

Previously `requireLast` did nothing when turned off, and enforced having a delimiter when turned on.

I felt this was inconsistent with the goals of the linter; being a tool to provide consistent coding conventions.

This is the first of two changes to bring the option into line with eslint's [`comma-dangle`](https://eslint.org/docs/rules/comma-dangle#options). (The next change will replace the boolean with an enum; I didn't want to overload this PR).

### Breaking change:
- `requireLast: false` now enforces that there is no delimiter on the last member.