### PR TITLE
[FEAT][BREAKING][2/2][member-delimiter-style] Separate single/multiline config

### DIFF
--- a/docs/rules/member-delimiter-style.md
+++ b/docs/rules/member-delimiter-style.md
@@ -5,12 +5,12 @@ Enforces a consistent member delimiter style in interfaces and type literals. Th
 ```ts
 interface Foo {
     name: string;
-    greet(): void; // last semicolon can be ignored
+    greet(): void;
 }
 
 type Bar = {
     name: string;
-    greet(): void; // last semicolon can be ignored
+    greet(): void;
 }
 ```
 
@@ -18,12 +18,12 @@ type Bar = {
 ```ts
 interface Foo {
     name: string,
-    greet(): void, // last comma can be ignored
+    greet(): void,
 }
 
 type Bar = {
     name: string,
-    greet(): void, // last comma can be ignored
+    greet(): void,
 }
 ```
 
@@ -40,7 +40,8 @@ type Bar = {
 }
 ```
 
-The rule also enforces the presence of the delimiter in the last member of the interface and/or type literal, allowing single line declarations to be ignored.
+The rule also enforces the presence (or absence) of the delimiter in the last member of the interface and/or type literal.
+Finally, this rule can enforce separate delimiter syntax for single line declarations.
 
 ## Rule Details
 
@@ -58,13 +59,16 @@ The rule can also take one or more of the following options:
 - `"delimiter": "none"`, use this to require a linebreak.
 - `"requireLast": true`, (default) use this to require a delimiter for all members of the interface and/or type literal.
 - `"requireLast": false`, use this to ignore the last member of the interface and/or type literal.
-- `"ignoreSingleLine": true`, (default) use this to override the `requireLast` in single line declarations.
-- `"ignoreSingleLine": false`, use this to enfore the `requireLast` in single line declarations.
+- `"singleLine": "semi"`, (default) use this to require a semicolon in single line declarations.
+- `"singleLine": "comma"`, use this to require a comma in single line declarations.
+- `"singleLine": "none"`, use this to require a linebreak (i.e. disallow mulit prop, single line declarations).
 - `"overrides"`, overrides the default options for **interfaces** and **type literals**.
+
+*Note that `delimiter` and `singleLine` are independent options - if you don't provide a value for either they will use their default option.*
 
 ### defaults
 Examples of **incorrect** code for this rule with the defaults
-`{ delimiter: "semi", requireLast: true, ignoreSingleLine: true }` or no option at all:
+`{ delimiter: "semi", requireLast: true, singleLine: "semi" }` or no option at all:
 ```ts
 // missing semicolon delimiter
 interface Foo {
@@ -101,17 +105,18 @@ type Baz = {
     name: string,
     greet(): string
 }
+
+// incorrect delimiter
+type FooBar = { name: string, greet(): string }
 ```
 
 Examples of **correct** code for this rule with the default
-`{ delimiter: "semi", requireLast: true, ignoreSingleLine: true }`:
+`{ delimiter: "semi", requireLast: true, singleLine: "semi" }`:
 ```ts
 interface Foo {
     name: string;
     greet(): string;
 }
-
-interface Foo { name: string }
 
 interface Foo { name: string; }
 
@@ -120,9 +125,9 @@ type Bar = {
     greet(): string;
 }
 
-type Bar = { name: string }
-
 type Bar = { name: string; }
+
+type FooBar = { name: string; greet(): string; }
 ```
 
 ### delimiter - semi
@@ -143,12 +148,11 @@ interface Bar {
 
 Examples of **correct** code for this rule with `{ delimiter: "semi" }`:
 ```ts
-// with requireLast = true/false
+// with requireLast = true
 interface Foo {
     name: string;
     greet(): string;
 }
-
 type Bar = {
     name: string;
     greet(): string;
@@ -159,7 +163,6 @@ interface Foo {
     name: string;
     greet(): string
 }
-
 type Bar = {
     name: string;
     greet(): string
@@ -184,12 +187,11 @@ interface Bar {
 
 Examples of **correct** code for this rule with `{ delimiter: "comma" }`:
 ```ts
-// with requireLast = true/false
+// with requireLast = true
 interface Foo {
     name: string,
     greet(): string,
 }
-
 type Bar = {
     name: string,
     greet(): string,
@@ -299,42 +301,72 @@ type Baz = {
 ```
 
 ### ignoreSingleLine
-Examples of **incorrect** code for this rule with `{ ignoreSingleLine: true }`:
+Examples of **incorrect** code for this rule with `{ singleLine: "semi" }`:
 ```ts
 // using incorrect delimiter
 interface Foo { name: string, }
+interface Foo { name: string, greet(): string, }
 
-// using incorrect delimiter
 type Bar = { name: string, }
+type Bar = { name: string, greet(): string, }
 ```
 
-Examples of **correct** code for this rule with `{ ignoreSingleLine: true }`:
-```ts
-// can have a delimiter or not
-interface Foo { name: string }
-
-interface Foo { name: string; }
-
-// can have a delimiter or not
-type Bar = { name: string }
-
-type Bar = { name: string; }
-```
-
-Examples of **incorrect** code for this rule with `{ ignoreSingleLine: false }`:
-```ts
-// missing delimiter
-interface Foo { name: string }
-
-// missing delimiter
-type Bar = { name: string }
-```
-
-Examples of **correct** code for this rule with `{ ignoreSingleLine: false }`:
+Examples of **correct** code for this rule with `{ singleLine: "semi" }`:
 ```ts
 interface Foo { name: string; }
+interface Foo { name: string; greet(): string; }
 
 type Bar = { name: string; }
+type Bar = { name: string; greet(): string; }
+```
+
+Examples of **incorrect** code for this rule with `{ singleLine: "comma" }`:
+```ts
+// using incorrect delimiter
+interface Foo { name: string; }
+interface Foo { name: string; greet(): string; }
+
+type Bar = { name: string; }
+type Bar = { name: string; greet(): string; }
+```
+
+Examples of **correct** code for this rule with `{ singleLine: "comma" }`:
+```ts
+interface Foo { name: string, }
+interface Foo { name: string, greet(): string, }
+
+type Bar = { name: string, }
+type Bar = { name: string, greet(): string, }
+```
+
+Examples of **incorrect** code for this rule with `{ singleLine: "none" }`:
+```ts
+// has a delimiter when it shouldn't
+interface Foo { name: string; }
+interface Foo { name: string; greet(): string; }
+interface Foo { name: string, }
+interface Foo { name: string, greet(): string, }
+
+type Bar = { name: string; }
+type Bar = { name: string; greet(): string; }
+type Bar = { name: string, }
+type Bar = { name: string, greet(): string, }
+```
+
+Examples of **correct** code for this rule with `{ singleLine: "none" }`:
+```ts
+interface Foo { name: string }
+type Bar = { name: string }
+
+// Note that there is no syntax-valid way to do types single-line without a delimiter
+interface Foo {
+    name: string
+    greet(): string
+}
+type Bar = {
+    name: string
+    greet(): string
+}
 ```
 
 ### overrides - interface

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -19,17 +19,6 @@ const definition = {
     additionalProperties: false,
 };
 
-const errorMessages = {
-    unexpected: {
-        comma: "Unexpected separator (,).",
-        semi: "Unexpected separator (;).",
-    },
-    expected: {
-        comma: "Expected a comma.",
-        semi: "Expected a semicolon.",
-    },
-};
-
 module.exports = {
     meta: {
         docs: {
@@ -40,6 +29,12 @@ module.exports = {
                 "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/member-delimiter-style.md",
         },
         fixable: "code",
+        messages: {
+            unexpectedComma: "Unexpected separator (,).",
+            unexpectedSemi: "Unexpected separator (;).",
+            expectedComma: "Expected a comma.",
+            expectedSemi: "Expected a semicolon.",
+        },
         schema: [
             {
                 type: "object",
@@ -104,25 +99,19 @@ module.exports = {
              * @returns {boolean} the resolved value
              */
             function getOption(type) {
-                // eslint-disable-next-line require-jsdoc
-                function getValue() {
-                    if (isSameLine) {
-                        return opts.singleLine === type;
-                    }
-                    return opts.delimiter === type;
-                }
-
-                if (isLast) {
-                    if (opts.requireLast) {
-                        return getValue();
-                    }
+                if (isLast && !opts.requireLast) {
+                    // only turn the option on if its expecting no delimiter for the last member
                     return type === "none";
                 }
-
-                return getValue();
+                if (isSameLine) {
+                    // use single line config
+                    return opts.singleLine === type;
+                }
+                // use normal config
+                return opts.delimiter === type;
             }
 
-            let message;
+            let messageId;
             let missingDelimiter = false;
             const lastToken = sourceCode.getLastToken(member, {
                 includeComments: false,
@@ -134,29 +123,29 @@ module.exports = {
 
             if (lastToken.value === ";") {
                 if (optsComma) {
-                    message = errorMessages.expected.comma;
+                    messageId = "expectedComma";
                 } else if (optsNone) {
                     missingDelimiter = true;
-                    message = errorMessages.unexpected.semi;
+                    messageId = "unexpectedSemi";
                 }
             } else if (lastToken.value === ",") {
                 if (optsSemi) {
-                    message = errorMessages.expected.semi;
+                    messageId = "expectedSemi";
                 } else if (optsNone) {
                     missingDelimiter = true;
-                    message = errorMessages.unexpected.comma;
+                    messageId = "unexpectedComma";
                 }
             } else {
                 if (optsSemi) {
                     missingDelimiter = true;
-                    message = errorMessages.expected.semi;
+                    messageId = "expectedSemi";
                 } else if (optsComma) {
                     missingDelimiter = true;
-                    message = errorMessages.expected.comma;
+                    messageId = "expectedComma";
                 }
             }
 
-            if (message) {
+            if (messageId) {
                 context.report({
                     node: lastToken,
                     loc: {
@@ -169,7 +158,7 @@ module.exports = {
                             column: lastToken.loc.end.column,
                         },
                     },
-                    message,
+                    messageId,
                     fix(fixer) {
                         if (optsNone) {
                             // remove the unneeded token
@@ -222,6 +211,4 @@ module.exports = {
             TSTypeLiteral: checkMemberSeparatorStyle,
         };
     },
-
-    errorMessages,
 };

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces a member delimiter style in interfaces and type literals.
  * @author Patricio Trevino
+ * @author Brad Zacher
  */
 "use strict";
 
@@ -13,9 +14,20 @@ const definition = {
     properties: {
         delimiter: { enum: ["none", "semi", "comma"] },
         requireLast: { type: "boolean" },
-        ignoreSingleLine: { type: "boolean" },
+        singleLine: { enum: ["none", "semi", "comma"] },
     },
     additionalProperties: false,
+};
+
+const errorMessages = {
+    unexpected: {
+        comma: "Unexpected separator (,).",
+        semi: "Unexpected separator (;).",
+    },
+    expected: {
+        comma: "Expected a comma.",
+        semi: "Expected a semicolon.",
+    },
 };
 
 module.exports = {
@@ -31,10 +43,7 @@ module.exports = {
         schema: [
             {
                 type: "object",
-                properties: {
-                    delimiter: { enum: ["none", "semi", "comma"] },
-                    requireLast: { type: "boolean" },
-                    ignoreSingleLine: { type: "boolean" },
+                properties: Object.assign({}, definition.properties, {
                     overrides: {
                         type: "object",
                         properties: {
@@ -43,7 +52,7 @@ module.exports = {
                         },
                         additionalProperties: false,
                     },
-                },
+                }),
                 additionalProperties: false,
             },
         ],
@@ -57,7 +66,7 @@ module.exports = {
         const defaults = {
             delimiter: "semi",
             requireLast: true,
-            ignoreSingleLine: true,
+            singleLine: "semi",
         };
 
         const interfaceOptions = Object.assign(
@@ -89,41 +98,61 @@ module.exports = {
          * @private
          */
         function checkLastToken(member, opts, isLast, isSameLine) {
+            /**
+             * Resolves the boolean value for the given setting enum value
+             * @param {"semi" | "comma" | "none"} type the option name
+             * @returns {boolean} the resolved value
+             */
+            function getOption(type) {
+                // eslint-disable-next-line require-jsdoc
+                function getValue() {
+                    if (isSameLine) {
+                        return opts.singleLine === type;
+                    }
+                    return opts.delimiter === type;
+                }
+
+                if (isLast) {
+                    if (opts.requireLast) {
+                        return getValue();
+                    }
+                    return type === "none";
+                }
+
+                return getValue();
+            }
+
             let message;
             let missingDelimiter = false;
             const lastToken = sourceCode.getLastToken(member, {
                 includeComments: false,
             });
 
-            if (lastToken.value === ";" && opts.delimiter !== "semi") {
-                message =
-                    opts.delimiter === "comma"
-                        ? "Expected a comma."
-                        : "Unexpected separator (;).";
-            } else if (lastToken.value === "," && opts.delimiter !== "comma") {
-                message =
-                    opts.delimiter === "semi"
-                        ? "Expected a semicolon."
-                        : "Unexpected separator (,).";
-            } else if (
-                lastToken.value !== ";" &&
-                lastToken.value !== "," &&
-                opts.delimiter !== "none"
-            ) {
-                let canOmit = isLast;
+            const optsSemi = getOption("semi");
+            const optsComma = getOption("comma");
+            const optsNone = getOption("none");
 
-                if (canOmit) {
-                    canOmit =
-                        !opts.requireLast ||
-                        (isSameLine && opts.ignoreSingleLine);
-                }
-
-                if (!canOmit) {
+            if (lastToken.value === ";") {
+                if (optsComma) {
+                    message = errorMessages.expected.comma;
+                } else if (optsNone) {
                     missingDelimiter = true;
-                    message =
-                        opts.delimiter === "semi"
-                            ? "Expected a semicolon."
-                            : "Expected a comma.";
+                    message = errorMessages.unexpected.semi;
+                }
+            } else if (lastToken.value === ",") {
+                if (optsSemi) {
+                    message = errorMessages.expected.semi;
+                } else if (optsNone) {
+                    missingDelimiter = true;
+                    message = errorMessages.unexpected.comma;
+                }
+            } else {
+                if (optsSemi) {
+                    missingDelimiter = true;
+                    message = errorMessages.expected.semi;
+                } else if (optsComma) {
+                    missingDelimiter = true;
+                    message = errorMessages.expected.comma;
                 }
             }
 
@@ -142,24 +171,16 @@ module.exports = {
                     },
                     message,
                     fix(fixer) {
-                        let token;
-
-                        if (opts.delimiter === "semi") {
-                            token = ";";
-                        } else if (opts.delimiter === "comma") {
-                            token = ",";
-                        } else {
+                        if (optsNone) {
                             // remove the unneeded token
                             return fixer.remove(lastToken);
                         }
 
+                        const token = optsSemi ? ";" : ",";
+
                         if (missingDelimiter) {
                             // add the missing delimiter
                             return fixer.insertTextAfter(lastToken, token);
-                        }
-
-                        if (isLast && !opts.requireLast) {
-                            return fixer.remove(lastToken);
                         }
 
                         // correct the current delimiter
@@ -176,14 +197,16 @@ module.exports = {
          * @private
          */
         function checkMemberSeparatorStyle(node) {
-            const isSingleLine = node.loc.start.line === node.loc.end.line;
             const isInterface = node.type === "TSInterfaceBody";
+
+            const isSingleLine = node.loc.start.line === node.loc.end.line;
+            const opts = isInterface ? interfaceOptions : typeLiteralOptions;
             const members = isInterface ? node.body : node.members;
 
             members.forEach((member, index) => {
                 checkLastToken(
                     member,
-                    isInterface ? interfaceOptions : typeLiteralOptions,
+                    opts,
                     index === members.length - 1,
                     isSingleLine
                 );
@@ -199,4 +222,6 @@ module.exports = {
             TSTypeLiteral: checkMemberSeparatorStyle,
         };
     },
+
+    errorMessages,
 };

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -207,12 +207,7 @@ module.exports = {
                 : typeOpts.multiline;
 
             members.forEach((member, index) => {
-                checkLastToken(
-                    member,
-                    opts,
-                    index === members.length - 1,
-                    isSingleLine
-                );
+                checkLastToken(member, opts, index === members.length - 1);
             });
         }
 

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -11,19 +11,26 @@ const { deepMerge } = require("../util");
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const config = {
-    type: "object",
-    properties: {
-        delimiter: { enum: ["none", "semi", "comma"] },
-        requireLast: { type: "boolean" },
-    },
-    additionalProperties: false,
-};
 const definition = {
     type: "object",
     properties: {
-        multiline: config,
-        singleline: config,
+        multiline: {
+            type: "object",
+            properties: {
+                delimiter: { enum: ["none", "semi", "comma"] },
+                requireLast: { type: "boolean" },
+            },
+            additionalProperties: false,
+        },
+        singleline: {
+            type: "object",
+            properties: {
+                // note can't have "none" for single line delimiter as it's invlaid syntax
+                delimiter: { enum: ["semi", "comma"] },
+                requireLast: { type: "boolean" },
+            },
+            additionalProperties: false,
+        },
     },
     additionalProperties: false,
 };

--- a/lib/rules/member-delimiter-style.js
+++ b/lib/rules/member-delimiter-style.js
@@ -5,16 +5,25 @@
  */
 "use strict";
 
+const { deepMerge } = require("../util");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const definition = {
+const config = {
     type: "object",
     properties: {
         delimiter: { enum: ["none", "semi", "comma"] },
         requireLast: { type: "boolean" },
-        singleLine: { enum: ["none", "semi", "comma"] },
+    },
+    additionalProperties: false,
+};
+const definition = {
+    type: "object",
+    properties: {
+        multiline: config,
+        singleline: config,
     },
     additionalProperties: false,
 };
@@ -26,7 +35,7 @@ module.exports = {
                 "Require a specific member delimiter style for interfaces and type literals",
             category: "TypeScript",
             url:
-                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/member-delimiter-style.md",
+                "https://github.com/bradzacher/eslint-plugin-typescript/blob/master/docs/rules/member-delimiter-style.md",
         },
         fixable: "code",
         messages: {
@@ -59,21 +68,20 @@ module.exports = {
 
         const overrides = options.overrides || {};
         const defaults = {
-            delimiter: "semi",
-            requireLast: true,
-            singleLine: "semi",
+            multiline: {
+                delimiter: "semi",
+                requireLast: true,
+            },
+            singleline: {
+                delimiter: "semi",
+                requireLast: false,
+            },
         };
 
-        const interfaceOptions = Object.assign(
-            {},
-            defaults,
-            options,
-            overrides.interface
-        );
-        const typeLiteralOptions = Object.assign(
-            {},
-            defaults,
-            options,
+        const baseOptions = deepMerge(defaults, options);
+        const interfaceOptions = deepMerge(baseOptions, overrides.interface);
+        const typeLiteralOptions = deepMerge(
+            baseOptions,
             overrides.typeLiteral
         );
 
@@ -87,12 +95,10 @@ module.exports = {
          * @param {Object} opts the options to be validated.
          * @param {boolean} isLast a flag indicating `member` is the last in the
          *                         interface or type literal.
-         * @param {boolean} isSameLine a flag indicating the interface or type
-         *                             literal was declared in a single line.
          * @returns {void}
          * @private
          */
-        function checkLastToken(member, opts, isLast, isSameLine) {
+        function checkLastToken(member, opts, isLast) {
             /**
              * Resolves the boolean value for the given setting enum value
              * @param {"semi" | "comma" | "none"} type the option name
@@ -103,11 +109,6 @@ module.exports = {
                     // only turn the option on if its expecting no delimiter for the last member
                     return type === "none";
                 }
-                if (isSameLine) {
-                    // use single line config
-                    return opts.singleLine === type;
-                }
-                // use normal config
                 return opts.delimiter === type;
             }
 
@@ -187,10 +188,16 @@ module.exports = {
          */
         function checkMemberSeparatorStyle(node) {
             const isInterface = node.type === "TSInterfaceBody";
-
             const isSingleLine = node.loc.start.line === node.loc.end.line;
-            const opts = isInterface ? interfaceOptions : typeLiteralOptions;
+
             const members = isInterface ? node.body : node.members;
+
+            const typeOpts = isInterface
+                ? interfaceOptions
+                : typeLiteralOptions;
+            const opts = isSingleLine
+                ? typeOpts.singleline
+                : typeOpts.multiline;
 
             members.forEach((member, index) => {
                 checkLastToken(

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,14 +13,12 @@ exports.isTypescript = fileName => /\.tsx?$/.test(fileName);
 /**
  * Pure function - doesn't mutate either parameter!
  * Merges two objects together deeply, overwriting the properties in first with the properties in second
- * @param {TemplateStringsArray} first The first object
- * @param {Object} second The second object
- * @returns {Object} a new object
+ * @template TFirst,TSecond
+ * @param {TFirst} first The first object
+ * @param {TSecond} second The second object
+ * @returns {Record<string, any>} a new object
  */
-function deepMerge(first, second) {
-    first = first || {};
-    second = second || {};
-
+function deepMerge(first = {}, second = {}) {
     // get the unique set of keys across both objects
     const keys = new Set(Object.keys(first).concat(Object.keys(second)));
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,3 +9,45 @@ exports.tslintRule = name => `\`${name}\` from TSLint`;
  * @private
  */
 exports.isTypescript = fileName => /\.tsx?$/.test(fileName);
+
+/**
+ * Pure function - doesn't mutate either parameter!
+ * Merges two objects together deeply, overwriting the properties in first with the properties in second
+ * @param {TemplateStringsArray} first The first object
+ * @param {Object} second The second object
+ * @returns {Object} a new object
+ */
+function deepMerge(first, second) {
+    first = first || {};
+    second = second || {};
+
+    // get the unique set of keys across both objects
+    const keys = new Set(Object.keys(first).concat(Object.keys(second)));
+
+    return Array.from(keys).reduce((acc, key) => {
+        const firstHasKey = key in first;
+        const secondHasKey = key in second;
+
+        if (firstHasKey && secondHasKey) {
+            if (
+                typeof first[key] === "object" &&
+                !Array.isArray(first[key]) &&
+                typeof second[key] === "object" &&
+                !Array.isArray(second[key])
+            ) {
+                // object type
+                acc[key] = deepMerge(first[key], second[key]);
+            } else {
+                // value type
+                acc[key] = second[key];
+            }
+        } else if (firstHasKey) {
+            acc[key] = first[key];
+        } else {
+            acc[key] = second[key];
+        }
+
+        return acc;
+    }, {});
+}
+exports.deepMerge = deepMerge;

--- a/tests/lib/rules/member-delimiter-style.js
+++ b/tests/lib/rules/member-delimiter-style.js
@@ -37,70 +37,11 @@ interface Foo {
     age: number;
 }
                     `,
-            options: [{ delimiter: "semi", requireLast: true }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-                    `,
-            options: [{ delimiter: "semi" }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number
-}
-                    `,
-            options: [{ delimiter: "semi", requireLast: false }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number,
-}
-                    `,
-            options: [{ delimiter: "comma", requireLast: true }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number,
-}
-                    `,
-            options: [{ delimiter: "comma" }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number
-}
-                    `,
-            options: [{ delimiter: "comma", requireLast: false }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-                    `,
-            options: [{ delimiter: "none", requireLast: true }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-                    `,
-            options: [{ delimiter: "none", requireLast: false }],
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: true },
+                },
+            ],
         },
         {
             code: `
@@ -111,12 +52,105 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: false,
-                    overrides: {
-                        interface: {
-                            delimiter: "semi",
-                            requireLast: true,
+                    multiline: { delimiter: "semi" },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: false },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string,
+    age: number,
+}
+                    `,
+            options: [
+                {
+                    multiline: { delimiter: "comma", requireLast: true },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string,
+    age: number,
+}
+                    `,
+            options: [
+                {
+                    multiline: { delimiter: "comma" },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string,
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: { delimiter: "comma", requireLast: false },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: { delimiter: "none", requireLast: true },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: { delimiter: "none", requireLast: false },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "comma",
+                        requireLast: false,
+                        overrides: {
+                            interface: {
+                                delimiter: "semi",
+                                requireLast: true,
+                            },
                         },
                     },
                 },

--- a/tests/lib/rules/member-delimiter-style.js
+++ b/tests/lib/rules/member-delimiter-style.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforces a member delimiter style in interfaces and type literals.
  * @author Patricio Trevino
+ * @author Brad Zacher
  */
 "use strict";
 
@@ -19,21 +20,25 @@ const ruleTester = new RuleTester({
     parser: "typescript-eslint-parser",
 });
 
+const errors = rule.errorMessages;
+
 ruleTester.run("member-delimiter-style", rule, {
     valid: [
-        `
-interface Foo {
-    name: string;
-    age: number;
-}
-        `,
         {
             code: `
 interface Foo {
     name: string;
     age: number;
 }
-            `,
+                `,
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+                    `,
             options: [{ delimiter: "semi", requireLast: true }],
         },
         {
@@ -42,7 +47,7 @@ interface Foo {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [{ delimiter: "semi" }],
         },
         {
@@ -51,16 +56,7 @@ interface Foo {
     name: string;
     age: number
 }
-            `,
-            options: [{ delimiter: "semi", requireLast: false }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [{ delimiter: "semi", requireLast: false }],
         },
         {
@@ -69,7 +65,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: true }],
         },
         {
@@ -78,7 +74,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma" }],
         },
         {
@@ -87,16 +83,7 @@ interface Foo {
     name: string,
     age: number
 }
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: false }],
         },
         {
@@ -105,7 +92,7 @@ interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: true }],
         },
         {
@@ -114,7 +101,7 @@ interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: false }],
         },
         {
@@ -123,7 +110,7 @@ interface Foo {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -143,7 +130,7 @@ interface Foo {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -157,27 +144,7 @@ interface Foo {
     name: string;
     age: number
 }
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: true,
-                    overrides: {
-                        interface: {
-                            delimiter: "semi",
-                            requireLast: false,
-                        },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -197,7 +164,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -217,7 +184,7 @@ interface Foo {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -231,7 +198,7 @@ interface Foo {
     name: string,
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -248,27 +215,10 @@ interface Foo {
         {
             code: `
 interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    overrides: {
-                        interface: { delimiter: "comma", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -285,7 +235,7 @@ interface Foo {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -302,7 +252,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
         },
         {
             code: `
@@ -310,7 +260,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [{ delimiter: "semi", requireLast: true }],
         },
         {
@@ -319,7 +269,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [{ delimiter: "semi" }],
         },
         {
@@ -328,16 +278,7 @@ type Foo = {
     name: string;
     age: number
 }
-            `,
-            options: [{ delimiter: "semi", requireLast: false }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [{ delimiter: "semi", requireLast: false }],
         },
         {
@@ -346,7 +287,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: true }],
         },
         {
@@ -355,7 +296,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [{ delimiter: "comma" }],
         },
         {
@@ -364,16 +305,7 @@ type Foo = {
     name: string,
     age: number
 }
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
+                    `,
             options: [{ delimiter: "comma", requireLast: false }],
         },
         {
@@ -382,7 +314,7 @@ type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: true }],
         },
         {
@@ -391,7 +323,7 @@ type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [{ delimiter: "none", requireLast: false }],
         },
         {
@@ -400,7 +332,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -417,7 +349,7 @@ type Foo = {
     name: string;
     age: number;
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -431,24 +363,7 @@ type Foo = {
     name: string;
     age: number
 }
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: true,
-                    overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
+                    `,
             options: [
                 {
                     delimiter: "comma",
@@ -465,7 +380,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -482,7 +397,7 @@ type Foo = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -496,7 +411,7 @@ type Foo = {
     name: string,
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -510,27 +425,10 @@ type Foo = {
         {
             code: `
 type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -547,7 +445,7 @@ type Foo = {
     name: string
     age: number
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "semi",
@@ -569,7 +467,7 @@ type Bar = {
     name: string,
     age: number,
 }
-            `,
+                    `,
             options: [
                 {
                     delimiter: "none",
@@ -580,13 +478,14 @@ type Bar = {
                 },
             ],
         },
-        "interface Foo { [key: string]: any }",
-        "interface Foo { [key: string]: any; }",
+        {
+            code: "interface Foo { [key: string]: any; }",
+        },
         {
             code: "interface Foo { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -595,7 +494,7 @@ type Bar = {
             options: [
                 {
                     delimiter: "comma",
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -603,7 +502,7 @@ type Bar = {
             code: "interface Foo { [key: string]: any; }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -612,7 +511,7 @@ type Bar = {
             options: [
                 {
                     delimiter: "comma",
-                    ignoreSingleLine: false,
+                    singleLine: "comma",
                 },
             ],
         },
@@ -620,9 +519,9 @@ type Bar = {
             code: "interface Foo { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        interface: { ignoreSingleLine: true },
+                        interface: { singleLine: "none" },
                     },
                 },
             ],
@@ -632,7 +531,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -641,7 +540,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -650,20 +549,21 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        interface: { ignoreSingleLine: true },
+                        interface: { singleLine: "none" },
                     },
                 },
             ],
         },
-        "type Foo = { [key: string]: any }",
-        "type Foo = { [key: string]: any; }",
+        {
+            code: "type Foo = { [key: string]: any; }",
+        },
         {
             code: "type Foo = { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -671,7 +571,7 @@ type Bar = {
             code: "type Foo = { [key: string]: any; }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -679,9 +579,9 @@ type Bar = {
             code: "type Foo = { [key: string]: any }",
             options: [
                 {
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        typeLiteral: { ignoreSingleLine: true },
+                        typeLiteral: { singleLine: "none" },
                     },
                 },
             ],
@@ -691,7 +591,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                 },
             ],
         },
@@ -700,7 +600,7 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
         },
@@ -709,9 +609,46 @@ type Bar = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                     overrides: {
-                        typeLiteral: { ignoreSingleLine: true },
+                        typeLiteral: { singleLine: "none" },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+
+interface Bar { name: string }
+                `,
+            options: [
+                {
+                    delimiter: "semi",
+                    requireLast: true,
+                    singleLine: "none",
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+
+type Bar = { name: string }
+                `,
+            options: [
+                {
+                    delimiter: "semi",
+                    requireLast: true,
+                    singleLine: "semi",
+                    overrides: {
+                        typeLiteral: { singleLine: "none" },
                     },
                 },
             ],
@@ -733,12 +670,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -760,12 +697,12 @@ interface Foo {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -787,12 +724,12 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -814,7 +751,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
@@ -836,7 +773,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -858,12 +795,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -885,12 +822,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -912,7 +849,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -934,12 +871,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -961,12 +898,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -988,7 +925,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1010,12 +947,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1037,12 +974,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1064,12 +1001,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1091,7 +1028,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -1113,7 +1050,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1135,12 +1072,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1162,12 +1099,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1189,7 +1126,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1211,7 +1148,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1238,12 +1175,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1273,12 +1210,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1308,7 +1245,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1335,12 +1272,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1370,12 +1307,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1405,7 +1342,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -1432,12 +1369,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1467,12 +1404,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1502,7 +1439,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1532,12 +1469,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1564,12 +1501,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1599,12 +1536,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1634,7 +1571,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -1664,7 +1601,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -1691,12 +1628,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1726,12 +1663,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1761,7 +1698,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -1791,7 +1728,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -1812,12 +1749,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1839,12 +1776,12 @@ type Foo = {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1866,12 +1803,12 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1893,7 +1830,7 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -1915,12 +1852,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1942,12 +1879,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -1969,7 +1906,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -1991,12 +1928,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2018,12 +1955,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2045,7 +1982,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2067,12 +2004,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2094,12 +2031,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2121,12 +2058,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2148,7 +2085,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -2170,7 +2107,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2192,12 +2129,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2219,12 +2156,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2246,7 +2183,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2268,7 +2205,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2295,12 +2232,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -2330,12 +2267,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -2365,7 +2302,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 4,
                     column: 16,
                 },
@@ -2392,12 +2329,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -2427,12 +2364,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 16,
                 },
@@ -2462,7 +2399,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
@@ -2489,12 +2426,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2524,12 +2461,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2559,7 +2496,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2589,12 +2526,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2621,12 +2558,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2656,12 +2593,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2691,7 +2628,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 3,
                     column: 18,
                 },
@@ -2721,7 +2658,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (;).",
+                    message: errors.unexpected.semi,
                     line: 4,
                     column: 17,
                 },
@@ -2748,12 +2685,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2783,12 +2720,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2818,7 +2755,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 3,
                     column: 18,
                 },
@@ -2848,7 +2785,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: "Unexpected separator (,).",
+                    message: errors.unexpected.comma,
                     line: 4,
                     column: 17,
                 },
@@ -2889,22 +2826,22 @@ type Bar = {
             ],
             errors: [
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a comma.",
+                    message: errors.expected.comma,
                     line: 4,
                     column: 17,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 8,
                     column: 18,
                 },
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 9,
                     column: 17,
                 },
@@ -2923,7 +2860,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -2940,10 +2877,10 @@ interface Foo {
     [key: string]: any;
 }
             `,
-            options: [{ ignoreSingleLine: true }],
+            options: [{ singleLine: "none" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -2952,10 +2889,10 @@ interface Foo {
         {
             code: "interface Foo { [key: string]: any }",
             output: "interface Foo { [key: string]: any; }",
-            options: [{ ignoreSingleLine: false }],
+            options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 35,
                 },
@@ -2967,12 +2904,12 @@ interface Foo {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 35,
                 },
@@ -2984,15 +2921,15 @@ interface Foo {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                     overrides: {
-                        interface: { ignoreSingleLine: false },
+                        interface: { singleLine: "semi" },
                     },
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 35,
                 },
@@ -3011,7 +2948,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -3028,10 +2965,10 @@ type Foo = {
     [key: string]: any;
 }
             `,
-            options: [{ ignoreSingleLine: true }],
+            options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 3,
                     column: 23,
                 },
@@ -3040,10 +2977,10 @@ type Foo = {
         {
             code: "type Foo = { [key: string]: any }",
             output: "type Foo = { [key: string]: any; }",
-            options: [{ ignoreSingleLine: false }],
+            options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 32,
                 },
@@ -3055,12 +2992,12 @@ type Foo = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: false,
+                    singleLine: "semi",
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
                     line: 1,
                     column: 32,
                 },
@@ -3072,15 +3009,118 @@ type Foo = {
             options: [
                 {
                     requireLast: true,
-                    ignoreSingleLine: true,
+                    singleLine: "none",
                     overrides: {
-                        typeLiteral: { ignoreSingleLine: false },
+                        typeLiteral: { singleLine: "semi" },
                     },
                 },
             ],
             errors: [
                 {
-                    message: "Expected a semicolon.",
+                    message: errors.expected.semi,
+                    line: 1,
+                    column: 32,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            options: [{ delimiter: "semi", requireLast: false }],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    delimiter: "comma",
+                    requireLast: true,
+                    overrides: {
+                        interface: {
+                            delimiter: "semi",
+                            requireLast: false,
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: "interface Foo { [key: string]: any }",
+            errors: [
+                {
+                    message: errors.expected.semi,
+                    line: 1,
+                    column: 35,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            options: [{ delimiter: "semi", requireLast: false }],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    delimiter: "comma",
+                    requireLast: true,
+                    overrides: {
+                        typeLiteral: { delimiter: "semi", requireLast: false },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    message: errors.unexpected.semi,
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: "type Foo = { [key: string]: any }",
+            errors: [
+                {
+                    message: errors.expected.semi,
                     line: 1,
                     column: 32,
                 },

--- a/tests/lib/rules/member-delimiter-style.js
+++ b/tests/lib/rules/member-delimiter-style.js
@@ -20,8 +20,6 @@ const ruleTester = new RuleTester({
     parser: "typescript-eslint-parser",
 });
 
-const errors = rule.errorMessages;
-
 ruleTester.run("member-delimiter-style", rule, {
     valid: [
         {
@@ -670,12 +668,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -697,12 +695,12 @@ interface Foo {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -724,12 +722,12 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -751,7 +749,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
@@ -773,7 +771,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -795,12 +793,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -822,12 +820,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -849,7 +847,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -871,12 +869,12 @@ interface Foo {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -898,12 +896,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -925,7 +923,7 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -947,12 +945,12 @@ interface Foo {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -974,12 +972,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1001,12 +999,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1028,7 +1026,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -1050,7 +1048,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1072,12 +1070,12 @@ interface Foo {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1099,12 +1097,12 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1126,7 +1124,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -1148,7 +1146,7 @@ interface Foo {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1175,12 +1173,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1210,12 +1208,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1245,7 +1243,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1272,12 +1270,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1307,12 +1305,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1342,7 +1340,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -1369,12 +1367,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1404,12 +1402,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1439,7 +1437,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -1469,12 +1467,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1501,12 +1499,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1536,12 +1534,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1571,7 +1569,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -1601,7 +1599,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -1628,12 +1626,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1663,12 +1661,12 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1698,7 +1696,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -1728,7 +1726,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1749,12 +1747,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1776,12 +1774,12 @@ type Foo = {
             options: [{ delimiter: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1803,12 +1801,12 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1830,7 +1828,7 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -1852,12 +1850,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1879,12 +1877,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -1906,7 +1904,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -1928,12 +1926,12 @@ type Foo = {
             options: [{ delimiter: "comma" }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1955,12 +1953,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: true }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -1982,7 +1980,7 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2004,12 +2002,12 @@ type Foo = {
             options: [{ delimiter: "comma", requireLast: false }],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2031,12 +2029,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2058,12 +2056,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2085,7 +2083,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -2107,7 +2105,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2129,12 +2127,12 @@ type Foo = {
             options: [{ delimiter: "none" }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2156,12 +2154,12 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: true }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2183,7 +2181,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2205,7 +2203,7 @@ type Foo = {
             options: [{ delimiter: "none", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2232,12 +2230,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -2267,12 +2265,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -2302,7 +2300,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 4,
                     column: 16,
                 },
@@ -2329,12 +2327,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -2364,12 +2362,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 16,
                 },
@@ -2399,7 +2397,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
@@ -2426,12 +2424,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2461,12 +2459,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2496,7 +2494,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2526,12 +2524,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2558,12 +2556,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2593,12 +2591,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2628,7 +2626,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 3,
                     column: 18,
                 },
@@ -2658,7 +2656,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -2685,12 +2683,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2720,12 +2718,12 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2755,7 +2753,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 3,
                     column: 18,
                 },
@@ -2785,7 +2783,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.comma,
+                    messageId: "unexpectedComma",
                     line: 4,
                     column: 17,
                 },
@@ -2826,22 +2824,22 @@ type Bar = {
             ],
             errors: [
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: errors.expected.comma,
+                    messageId: "expectedComma",
                     line: 4,
                     column: 17,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 8,
                     column: 18,
                 },
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 9,
                     column: 17,
                 },
@@ -2860,7 +2858,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2880,7 +2878,7 @@ interface Foo {
             options: [{ singleLine: "none" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2892,7 +2890,7 @@ interface Foo {
             options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -2909,7 +2907,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -2929,7 +2927,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -2948,7 +2946,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2968,7 +2966,7 @@ type Foo = {
             options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 3,
                     column: 23,
                 },
@@ -2980,7 +2978,7 @@ type Foo = {
             options: [{ singleLine: "semi" }],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },
@@ -2997,7 +2995,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },
@@ -3017,7 +3015,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },
@@ -3033,7 +3031,7 @@ interface Foo {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3060,7 +3058,7 @@ interface Foo {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3070,7 +3068,7 @@ interface Foo {
             code: "interface Foo { [key: string]: any }",
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 35,
                 },
@@ -3086,7 +3084,7 @@ type Foo = {
             options: [{ delimiter: "semi", requireLast: false }],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3110,7 +3108,7 @@ type Foo = {
             ],
             errors: [
                 {
-                    message: errors.unexpected.semi,
+                    messageId: "unexpectedSemi",
                     line: 4,
                     column: 17,
                 },
@@ -3120,7 +3118,7 @@ type Foo = {
             code: "type Foo = { [key: string]: any }",
             errors: [
                 {
-                    message: errors.expected.semi,
+                    messageId: "expectedSemi",
                     line: 1,
                     column: 32,
                 },

--- a/tests/lib/rules/member-delimiter-style.js
+++ b/tests/lib/rules/member-delimiter-style.js
@@ -146,8 +146,10 @@ interface Foo {
                     multiline: {
                         delimiter: "comma",
                         requireLast: false,
-                        overrides: {
-                            interface: {
+                    },
+                    overrides: {
+                        interface: {
+                            multiline: {
                                 delimiter: "semi",
                                 requireLast: true,
                             },
@@ -165,8 +167,12 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "comma",
-                    overrides: { interface: { delimiter: "semi" } },
+                    multiline: {
+                        delimiter: "comma",
+                    },
+                    overrides: {
+                        interface: { multiline: { delimiter: "semi" } },
+                    },
                 },
             ],
         },
@@ -179,12 +185,16 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: true,
+                    multiline: {
+                        delimiter: "comma",
+                        requireLast: true,
+                    },
                     overrides: {
                         interface: {
-                            delimiter: "semi",
-                            requireLast: false,
+                            multiline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
                         },
                     },
                 },
@@ -199,12 +209,16 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: false,
+                    },
                     overrides: {
                         interface: {
-                            delimiter: "comma",
-                            requireLast: true,
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: true,
+                            },
                         },
                     },
                 },
@@ -219,8 +233,12 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "semi",
-                    overrides: { interface: { delimiter: "comma" } },
+                    multiline: {
+                        delimiter: "semi",
+                    },
+                    overrides: {
+                        interface: { multiline: { delimiter: "comma" } },
+                    },
                 },
             ],
         },
@@ -233,12 +251,16 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: true,
+                    },
                     overrides: {
                         interface: {
-                            delimiter: "comma",
-                            requireLast: false,
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
                         },
                     },
                 },
@@ -253,10 +275,14 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: false,
+                    },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: true },
+                        interface: {
+                            multiline: { delimiter: "none", requireLast: true },
+                        },
                     },
                 },
             ],
@@ -270,10 +296,17 @@ interface Foo {
                     `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: true,
+                    },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -293,7 +326,7 @@ type Foo = {
     age: number;
 }
                     `,
-            options: [{ delimiter: "semi", requireLast: true }],
+            options: [{ multiline: { delimiter: "semi", requireLast: true } }],
         },
         {
             code: `
@@ -302,7 +335,7 @@ type Foo = {
     age: number;
 }
                     `,
-            options: [{ delimiter: "semi" }],
+            options: [{ multiline: { delimiter: "semi" } }],
         },
         {
             code: `
@@ -311,7 +344,7 @@ type Foo = {
     age: number
 }
                     `,
-            options: [{ delimiter: "semi", requireLast: false }],
+            options: [{ multiline: { delimiter: "semi", requireLast: false } }],
         },
         {
             code: `
@@ -320,7 +353,7 @@ type Foo = {
     age: number,
 }
                     `,
-            options: [{ delimiter: "comma", requireLast: true }],
+            options: [{ multiline: { delimiter: "comma", requireLast: true } }],
         },
         {
             code: `
@@ -329,113 +362,7 @@ type Foo = {
     age: number,
 }
                     `,
-            options: [{ delimiter: "comma" }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number
-}
-                    `,
-            options: [{ delimiter: "comma", requireLast: false }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-                    `,
-            options: [{ delimiter: "none", requireLast: true }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-                    `,
-            options: [{ delimiter: "none", requireLast: false }],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-                    `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: false,
-                    overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: true },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-                    `,
-            options: [
-                {
-                    delimiter: "comma",
-                    overrides: { typeLiteral: { delimiter: "semi" } },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number
-}
-                    `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: true,
-                    overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: false },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number,
-}
-                    `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: false,
-                    overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: true },
-                    },
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number,
-}
-                    `,
-            options: [
-                {
-                    delimiter: "semi",
-                    overrides: { typeLiteral: { delimiter: "comma" } },
-                },
-            ],
+            options: [{ multiline: { delimiter: "comma" } }],
         },
         {
             code: `
@@ -445,13 +372,7 @@ type Foo = {
 }
                     `,
             options: [
-                {
-                    delimiter: "semi",
-                    requireLast: false,
-                    overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: false },
-                    },
-                },
+                { multiline: { delimiter: "comma", requireLast: false } },
             ],
         },
         {
@@ -461,12 +382,142 @@ type Foo = {
     age: number
 }
                     `,
+            options: [{ multiline: { delimiter: "none", requireLast: true } }],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+                    `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+                    `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: {
+                        delimiter: "comma",
+                        requireLast: false,
+                    },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: true },
+                        typeLiteral: {
+                            multiline: { delimiter: "semi", requireLast: true },
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "comma",
+                    },
+                    overrides: {
+                        typeLiteral: { multiline: { delimiter: "semi" } },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "comma",
+                        requireLast: true,
+                    },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string,
+    age: number,
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: false,
+                    },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: true,
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string,
+    age: number,
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "semi",
+                    },
+                    overrides: {
+                        typeLiteral: { multiline: { delimiter: "comma" } },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string,
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: false,
+                    },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -480,10 +531,38 @@ type Foo = {
                     `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: false,
+                    },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: false },
+                        typeLiteral: {
+                            multiline: { delimiter: "none", requireLast: true },
+                        },
+                    },
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+                    `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: true,
+                    },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -502,149 +581,167 @@ type Bar = {
                     `,
             options: [
                 {
-                    delimiter: "none",
+                    multiline: {
+                        delimiter: "none",
+                    },
                     overrides: {
-                        interface: { delimiter: "semi" },
-                        typeLiteral: { delimiter: "comma" },
+                        interface: { multiline: { delimiter: "semi" } },
+                        typeLiteral: { multiline: { delimiter: "comma" } },
                     },
                 },
             ],
         },
         {
-            code: "interface Foo { [key: string]: any; }",
+            code: "interface Foo { a: any; [key: string]: any }",
         },
         {
-            code: "interface Foo { [key: string]: any }",
+            code: "interface Foo { a: any; [key: string]: any }",
             options: [
                 {
-                    singleLine: "none",
+                    singleline: { requireLast: false },
                 },
             ],
         },
         {
-            code: "interface Foo { [key: string]: any }",
+            code: "interface Foo { a: any; [key: string]: any; }",
             options: [
                 {
-                    delimiter: "comma",
-                    singleLine: "none",
+                    singleline: { requireLast: true },
                 },
             ],
         },
         {
-            code: "interface Foo { [key: string]: any; }",
+            code: "interface Foo { a: any, [key: string]: any }",
             options: [
                 {
-                    singleLine: "semi",
+                    singleline: { delimiter: "comma" },
                 },
             ],
         },
         {
-            code: "interface Foo { [key: string]: any, }",
+            code: "interface Foo { a: any, [key: string]: any, }",
             options: [
                 {
-                    delimiter: "comma",
-                    singleLine: "comma",
+                    singleline: { delimiter: "comma", requireLast: true },
                 },
             ],
         },
         {
-            code: "interface Foo { [key: string]: any }",
+            code: "interface Foo { a: any, [key: string]: any }",
             options: [
                 {
-                    singleLine: "semi",
-                    overrides: {
-                        interface: { singleLine: "none" },
+                    singleline: { delimiter: "comma", requireLast: false },
+                },
+            ],
+        },
+        {
+            code: "interface Foo { a: any; [key: string]: any }",
+            options: [
+                {
+                    singleline: { delimiter: "semi" },
+                },
+            ],
+        },
+        {
+            code: "interface Foo { a: any; [key: string]: any; }",
+            options: [
+                {
+                    singleline: { delimiter: "semi", requireLast: true },
+                },
+            ],
+        },
+        {
+            code: "interface Foo { a: any; [key: string]: any }",
+            options: [
+                {
+                    singleline: { delimiter: "semi", requireLast: false },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any; [key: string]: any }",
+        },
+        {
+            code: "type Foo = { a: any; [key: string]: any }",
+            options: [
+                {
+                    singleline: { requireLast: false },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any; [key: string]: any; }",
+            options: [
+                {
+                    singleline: { requireLast: true },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any, [key: string]: any }",
+            options: [
+                {
+                    singleline: { delimiter: "comma" },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any, [key: string]: any, }",
+            options: [
+                {
+                    singleline: { delimiter: "comma", requireLast: true },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any, [key: string]: any }",
+            options: [
+                {
+                    singleline: { delimiter: "comma", requireLast: false },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any; [key: string]: any }",
+            options: [
+                {
+                    singleline: { delimiter: "semi" },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any; [key: string]: any; }",
+            options: [
+                {
+                    singleline: { delimiter: "semi", requireLast: true },
+                },
+            ],
+        },
+        {
+            code: "type Foo = { a: any; [key: string]: any }",
+            options: [
+                {
+                    singleline: { delimiter: "semi", requireLast: false },
+                },
+            ],
+        },
+
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+
+interface Bar { name: string, age: number }
+                `,
+            options: [
+                {
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: true,
                     },
-                },
-            ],
-        },
-        {
-            code: "interface Foo { [key: string]: any }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "none",
-                },
-            ],
-        },
-        {
-            code: "interface Foo { [key: string]: any; }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "semi",
-                },
-            ],
-        },
-        {
-            code: "interface Foo { [key: string]: any }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "semi",
-                    overrides: {
-                        interface: { singleLine: "none" },
-                    },
-                },
-            ],
-        },
-        {
-            code: "type Foo = { [key: string]: any; }",
-        },
-        {
-            code: "type Foo = { [key: string]: any }",
-            options: [
-                {
-                    singleLine: "none",
-                },
-            ],
-        },
-        {
-            code: "type Foo = { [key: string]: any; }",
-            options: [
-                {
-                    singleLine: "semi",
-                },
-            ],
-        },
-        {
-            code: "type Foo = { [key: string]: any }",
-            options: [
-                {
-                    singleLine: "semi",
-                    overrides: {
-                        typeLiteral: { singleLine: "none" },
-                    },
-                },
-            ],
-        },
-        {
-            code: "type Foo = { [key: string]: any }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "none",
-                },
-            ],
-        },
-        {
-            code: "type Foo = { [key: string]: any; }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "semi",
-                },
-            ],
-        },
-        {
-            code: "type Foo = { [key: string]: any }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "semi",
-                    overrides: {
-                        typeLiteral: { singleLine: "none" },
-                    },
+                    singleline: { delimiter: "comma", requireLast: false },
                 },
             ],
         },
@@ -655,32 +752,22 @@ interface Foo {
     age: number;
 }
 
-interface Bar { name: string }
+type Bar = { name: string, age: number }
                 `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
-                    singleLine: "none",
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-
-type Bar = { name: string }
-                `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    singleLine: "semi",
+                    multiline: {
+                        delimiter: "semi",
+                        requireLast: true,
+                    },
+                    singleline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        typeLiteral: { singleLine: "none" },
+                        typeLiteral: {
+                            singleline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -726,7 +813,7 @@ interface Foo {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi" }],
+            options: [{ multiline: { delimiter: "semi" } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -753,7 +840,7 @@ interface Foo {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi", requireLast: true }],
+            options: [{ multiline: { delimiter: "semi", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -780,7 +867,7 @@ interface Foo {
     age: number
 }
             `,
-            options: [{ delimiter: "semi", requireLast: false }],
+            options: [{ multiline: { delimiter: "semi", requireLast: false } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -802,479 +889,7 @@ interface Foo {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi", requireLast: true }],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            options: [{ delimiter: "comma" }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: true }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            options: [{ delimiter: "comma" }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: true }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 18,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number;
-}
-            `,
-            output: `
-interface Foo {
-    name: string,
-    age: number
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none" }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: true }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 3,
-                    column: 18,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number;
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none" }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number,
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: true }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string,
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 3,
-                    column: 18,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number,
-}
-            `,
-            output: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    overrides: { interface: { delimiter: "semi" } },
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedSemi",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: false,
-                    overrides: {
-                        interface: { delimiter: "semi", requireLast: true },
-                    },
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedSemi",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-interface Foo {
-    name: string;
-    age: number
-}
-            `,
-            output: `
-interface Foo {
-    name: string;
-    age: number;
-}
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: false,
-                    overrides: {
-                        interface: { delimiter: "semi", requireLast: true },
-                    },
-                },
-            ],
+            options: [{ multiline: { delimiter: "semi", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -1296,12 +911,7 @@ interface Foo {
     age: number,
 }
             `,
-            options: [
-                {
-                    delimiter: "semi",
-                    overrides: { interface: { delimiter: "comma" } },
-                },
-            ],
+            options: [{ multiline: { delimiter: "comma" } }],
             errors: [
                 {
                     messageId: "expectedComma",
@@ -1328,15 +938,7 @@ interface Foo {
     age: number,
 }
             `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: false,
-                    overrides: {
-                        interface: { delimiter: "comma", requireLast: true },
-                    },
-                },
-            ],
+            options: [{ multiline: { delimiter: "comma", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedComma",
@@ -1364,13 +966,7 @@ interface Foo {
 }
             `,
             options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    overrides: {
-                        interface: { delimiter: "comma", requireLast: false },
-                    },
-                },
+                { multiline: { delimiter: "comma", requireLast: false } },
             ],
             errors: [
                 {
@@ -1393,12 +989,7 @@ interface Foo {
     age: number,
 }
             `,
-            options: [
-                {
-                    delimiter: "semi",
-                    overrides: { interface: { delimiter: "comma" } },
-                },
-            ],
+            options: [{ multiline: { delimiter: "comma" } }],
             errors: [
                 {
                     messageId: "expectedComma",
@@ -1425,12 +1016,534 @@ interface Foo {
     age: number,
 }
             `,
+            options: [{ multiline: { delimiter: "comma", requireLast: true } }],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number
+}
+            `,
+            options: [
+                { multiline: { delimiter: "comma", requireLast: false } },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number;
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number
+}
+            `,
+            options: [
+                { multiline: { delimiter: "comma", requireLast: false } },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none" } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: true } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 3,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number;
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string,
+    age: number,
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none" } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string,
+    age: number,
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: true } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string,
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 3,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number,
+}
+            `,
+            output: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: { delimiter: "comma" },
                     overrides: {
-                        interface: { delimiter: "comma", requireLast: true },
+                        interface: { multiline: { delimiter: "semi" } },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedSemi",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "comma", requireLast: false },
+                    overrides: {
+                        interface: {
+                            multiline: { delimiter: "semi", requireLast: true },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedSemi",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "comma", requireLast: false },
+                    overrides: {
+                        interface: {
+                            multiline: { delimiter: "semi", requireLast: true },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        interface: { multiline: { delimiter: "comma" } },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: false },
+                    overrides: {
+                        interface: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: true,
+                            },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string
+    age: number
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: true },
+                    overrides: {
+                        interface: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        interface: { multiline: { delimiter: "comma" } },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+interface Foo {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: false },
+                    overrides: {
+                        interface: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: true,
+                            },
+                        },
                     },
                 },
             ],
@@ -1462,10 +1575,14 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "comma", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -1492,10 +1609,14 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "comma", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -1527,8 +1648,10 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    overrides: { interface: { delimiter: "none" } },
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        interface: { multiline: { delimiter: "none" } },
+                    },
                 },
             ],
             errors: [
@@ -1559,10 +1682,11 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: { delimiter: "semi", requireLast: false },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: true },
+                        interface: {
+                            multiline: { delimiter: "none", requireLast: true },
+                        },
                     },
                 },
             ],
@@ -1594,10 +1718,14 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -1624,10 +1752,14 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -1654,8 +1786,10 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    overrides: { interface: { delimiter: "none" } },
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        interface: { multiline: { delimiter: "none" } },
+                    },
                 },
             ],
             errors: [
@@ -1686,10 +1820,11 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: { delimiter: "semi", requireLast: false },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: true },
+                        interface: {
+                            multiline: { delimiter: "none", requireLast: true },
+                        },
                     },
                 },
             ],
@@ -1721,10 +1856,14 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -1751,10 +1890,14 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "none", requireLast: false },
+                        interface: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -1805,7 +1948,7 @@ type Foo = {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi" }],
+            options: [{ multiline: { delimiter: "semi" } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -1832,7 +1975,7 @@ type Foo = {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi", requireLast: true }],
+            options: [{ multiline: { delimiter: "semi", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -1859,7 +2002,7 @@ type Foo = {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi", requireLast: true }],
+            options: [{ multiline: { delimiter: "semi", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -1881,7 +2024,7 @@ type Foo = {
     age: number,
 }
             `,
-            options: [{ delimiter: "comma" }],
+            options: [{ multiline: { delimiter: "comma" } }],
             errors: [
                 {
                     messageId: "expectedComma",
@@ -1908,492 +2051,7 @@ type Foo = {
     age: number,
 }
             `,
-            options: [{ delimiter: "comma", requireLast: true }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            options: [{ delimiter: "comma" }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: true }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 18,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number;
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number
-}
-            `,
-            options: [{ delimiter: "comma", requireLast: false }],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none" }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: true }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 3,
-                    column: 18,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number;
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedSemi",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none" }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: true }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 3,
-                    column: 18,
-                },
-                {
-                    messageId: "unexpectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string,
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 3,
-                    column: 18,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number,
-}
-            `,
-            output: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            options: [{ delimiter: "none", requireLast: false }],
-            errors: [
-                {
-                    messageId: "unexpectedComma",
-                    line: 4,
-                    column: 17,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    overrides: { typeLiteral: { delimiter: "semi" } },
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedSemi",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: false,
-                    overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: true },
-                    },
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedSemi",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string;
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string;
-    age: number;
-}
-            `,
-            options: [
-                {
-                    delimiter: "comma",
-                    requireLast: false,
-                    overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: true },
-                    },
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            options: [
-                {
-                    delimiter: "semi",
-                    overrides: { typeLiteral: { delimiter: "comma" } },
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedComma",
-                    line: 3,
-                    column: 17,
-                },
-                {
-                    messageId: "expectedComma",
-                    line: 4,
-                    column: 16,
-                },
-            ],
-        },
-        {
-            code: `
-type Foo = {
-    name: string
-    age: number
-}
-            `,
-            output: `
-type Foo = {
-    name: string,
-    age: number,
-}
-            `,
-            options: [
-                {
-                    delimiter: "semi",
-                    requireLast: false,
-                    overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: true },
-                    },
-                },
-            ],
+            options: [{ multiline: { delimiter: "comma", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedComma",
@@ -2421,13 +2079,7 @@ type Foo = {
 }
             `,
             options: [
-                {
-                    delimiter: "semi",
-                    requireLast: true,
-                    overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: false },
-                    },
-                },
+                { multiline: { delimiter: "comma", requireLast: false } },
             ],
             errors: [
                 {
@@ -2450,12 +2102,7 @@ type Foo = {
     age: number,
 }
             `,
-            options: [
-                {
-                    delimiter: "semi",
-                    overrides: { typeLiteral: { delimiter: "comma" } },
-                },
-            ],
+            options: [{ multiline: { delimiter: "comma" } }],
             errors: [
                 {
                     messageId: "expectedComma",
@@ -2482,12 +2129,534 @@ type Foo = {
     age: number,
 }
             `,
+            options: [{ multiline: { delimiter: "comma", requireLast: true } }],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number
+}
+            `,
+            options: [
+                { multiline: { delimiter: "comma", requireLast: false } },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number;
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number
+}
+            `,
+            options: [
+                { multiline: { delimiter: "comma", requireLast: false } },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none" } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: true } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 3,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number;
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedSemi",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string,
+    age: number,
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none" } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string,
+    age: number,
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: true } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "unexpectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string,
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 3,
+                    column: 18,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number,
+}
+            `,
+            output: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            options: [{ multiline: { delimiter: "none", requireLast: false } }],
+            errors: [
+                {
+                    messageId: "unexpectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: { delimiter: "comma" },
                     overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: true },
+                        typeLiteral: { multiline: { delimiter: "semi" } },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedSemi",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "comma", requireLast: false },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: { delimiter: "semi", requireLast: true },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedSemi",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "comma", requireLast: false },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: { delimiter: "semi", requireLast: true },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        typeLiteral: { multiline: { delimiter: "comma" } },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: false },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: true,
+                            },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 16,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string
+    age: number
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: true },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        typeLiteral: { multiline: { delimiter: "comma" } },
+                    },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedComma",
+                    line: 3,
+                    column: 18,
+                },
+                {
+                    messageId: "expectedComma",
+                    line: 4,
+                    column: 17,
+                },
+            ],
+        },
+        {
+            code: `
+type Foo = {
+    name: string;
+    age: number;
+}
+            `,
+            output: `
+type Foo = {
+    name: string,
+    age: number,
+}
+            `,
+            options: [
+                {
+                    multiline: { delimiter: "semi", requireLast: false },
+                    overrides: {
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: true,
+                            },
+                        },
                     },
                 },
             ],
@@ -2519,10 +2688,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -2549,10 +2722,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "comma", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "comma",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -2584,8 +2761,10 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    overrides: { typeLiteral: { delimiter: "none" } },
+                    multiline: { delimiter: "semi" },
+                    overrides: {
+                        typeLiteral: { multiline: { delimiter: "none" } },
+                    },
                 },
             ],
             errors: [
@@ -2616,10 +2795,11 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: false,
+                    multiline: { delimiter: "semi", requireLast: false },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: true },
+                        typeLiteral: {
+                            multiline: { delimiter: "none", requireLast: true },
+                        },
                     },
                 },
             ],
@@ -2651,10 +2831,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -2681,10 +2865,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "semi",
-                    requireLast: true,
+                    multiline: { delimiter: "semi", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -2711,8 +2899,10 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "comma",
-                    overrides: { typeLiteral: { delimiter: "none" } },
+                    multiline: { delimiter: "comma" },
+                    overrides: {
+                        typeLiteral: { multiline: { delimiter: "none" } },
+                    },
                 },
             ],
             errors: [
@@ -2743,10 +2933,11 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: false,
+                    multiline: { delimiter: "comma", requireLast: false },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: true },
+                        typeLiteral: {
+                            multiline: { delimiter: "none", requireLast: true },
+                        },
                     },
                 },
             ],
@@ -2778,10 +2969,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: true,
+                    multiline: { delimiter: "comma", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -2808,10 +3003,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: true,
+                    multiline: { delimiter: "comma", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "none", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -2848,11 +3047,10 @@ type Bar = {
             `,
             options: [
                 {
-                    delimiter: "none",
-                    requireLast: true,
+                    multiline: { delimiter: "none", requireLast: true },
                     overrides: {
-                        interface: { delimiter: "comma" },
-                        typeLiteral: { delimiter: "semi" },
+                        interface: { multiline: { delimiter: "comma" } },
+                        typeLiteral: { multiline: { delimiter: "semi" } },
                     },
                 },
             ],
@@ -2909,7 +3107,7 @@ interface Foo {
     [key: string]: any;
 }
             `,
-            options: [{ singleLine: "none" }],
+            options: [{ singleline: { delimiter: "comma" } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -2919,14 +3117,36 @@ interface Foo {
             ],
         },
         {
-            code: "interface Foo { [key: string]: any }",
-            output: "interface Foo { [key: string]: any; }",
-            options: [{ singleLine: "semi" }],
+            code: "interface Foo { a: any, [key: string]: any }",
+            output: "interface Foo { a: any; [key: string]: any }",
+            options: [{ singleline: { delimiter: "semi" } }],
             errors: [
                 {
                     messageId: "expectedSemi",
                     line: 1,
-                    column: 35,
+                    column: 24,
+                },
+            ],
+        },
+        {
+            code: "interface Foo { a: any, [key: string]: any, }",
+            output: "interface Foo { a: any; [key: string]: any }",
+            options: [
+                {
+                    multiline: { requireLast: true },
+                    singleline: { delimiter: "semi" },
+                },
+            ],
+            errors: [
+                {
+                    messageId: "expectedSemi",
+                    line: 1,
+                    column: 24,
+                },
+                {
+                    messageId: "unexpectedComma",
+                    line: 1,
+                    column: 44,
                 },
             ],
         },
@@ -2935,27 +3155,15 @@ interface Foo {
             output: "interface Foo { [key: string]: any; }",
             options: [
                 {
-                    requireLast: true,
-                    singleLine: "semi",
-                },
-            ],
-            errors: [
-                {
-                    messageId: "expectedSemi",
-                    line: 1,
-                    column: 35,
-                },
-            ],
-        },
-        {
-            code: "interface Foo { [key: string]: any }",
-            output: "interface Foo { [key: string]: any; }",
-            options: [
-                {
-                    requireLast: true,
-                    singleLine: "none",
+                    multiline: { requireLast: true },
+                    singleline: { delimiter: "comma", requireLast: false },
                     overrides: {
-                        interface: { singleLine: "semi" },
+                        interface: {
+                            singleline: {
+                                delimiter: "semi",
+                                requireLast: true,
+                            },
+                        },
                     },
                 },
             ],
@@ -2997,7 +3205,7 @@ type Foo = {
     [key: string]: any;
 }
             `,
-            options: [{ singleLine: "semi" }],
+            options: [{ singleline: { delimiter: "semi" } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -3009,7 +3217,7 @@ type Foo = {
         {
             code: "type Foo = { [key: string]: any }",
             output: "type Foo = { [key: string]: any; }",
-            options: [{ singleLine: "semi" }],
+            options: [{ singleline: { delimiter: "semi", requireLast: true } }],
             errors: [
                 {
                     messageId: "expectedSemi",
@@ -3023,8 +3231,8 @@ type Foo = {
             output: "type Foo = { [key: string]: any; }",
             options: [
                 {
-                    requireLast: true,
-                    singleLine: "semi",
+                    multiline: { requireLast: false },
+                    singleline: { delimiter: "semi", requireLast: true },
                 },
             ],
             errors: [
@@ -3036,14 +3244,14 @@ type Foo = {
             ],
         },
         {
-            code: "type Foo = { [key: string]: any }",
-            output: "type Foo = { [key: string]: any; }",
+            code: "type Foo = { a: any, [key: string]: any }",
+            output: "type Foo = { a: any; [key: string]: any }",
             options: [
                 {
-                    requireLast: true,
-                    singleLine: "none",
+                    multiline: { requireLast: true },
+                    singleline: { delimiter: "comma" },
                     overrides: {
-                        typeLiteral: { singleLine: "semi" },
+                        typeLiteral: { singleline: { delimiter: "semi" } },
                     },
                 },
             ],
@@ -3051,7 +3259,7 @@ type Foo = {
                 {
                     messageId: "expectedSemi",
                     line: 1,
-                    column: 32,
+                    column: 21,
                 },
             ],
         },
@@ -3062,7 +3270,7 @@ interface Foo {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi", requireLast: false }],
+            options: [{ multiline: { delimiter: "semi", requireLast: false } }],
             errors: [
                 {
                     messageId: "unexpectedSemi",
@@ -3080,12 +3288,13 @@ interface Foo {
             `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: true,
+                    multiline: { delimiter: "comma", requireLast: true },
                     overrides: {
                         interface: {
-                            delimiter: "semi",
-                            requireLast: false,
+                            multiline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
                         },
                     },
                 },
@@ -3099,12 +3308,12 @@ interface Foo {
             ],
         },
         {
-            code: "interface Foo { [key: string]: any }",
+            code: "interface Foo { a: any, [key: string]: any }",
             errors: [
                 {
                     messageId: "expectedSemi",
                     line: 1,
-                    column: 35,
+                    column: 24,
                 },
             ],
         },
@@ -3115,7 +3324,7 @@ type Foo = {
     age: number;
 }
             `,
-            options: [{ delimiter: "semi", requireLast: false }],
+            options: [{ multiline: { delimiter: "semi", requireLast: false } }],
             errors: [
                 {
                     messageId: "unexpectedSemi",
@@ -3133,10 +3342,14 @@ type Foo = {
             `,
             options: [
                 {
-                    delimiter: "comma",
-                    requireLast: true,
+                    multiline: { delimiter: "comma", requireLast: true },
                     overrides: {
-                        typeLiteral: { delimiter: "semi", requireLast: false },
+                        typeLiteral: {
+                            multiline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
+                        },
                     },
                 },
             ],
@@ -3149,12 +3362,12 @@ type Foo = {
             ],
         },
         {
-            code: "type Foo = { [key: string]: any }",
+            code: "type Foo = { a: any, [key: string]: any }",
             errors: [
                 {
                     messageId: "expectedSemi",
                     line: 1,
-                    column: 32,
+                    column: 21,
                 },
             ],
         },


### PR DESCRIPTION
#### PRing against #203's branch for now so it's easier to see the changes in this PR.

## Breaking change:
Changed config to split single and multiline config into two separate objects for better customisability
Before:
```ts
type Delimiter = 'none' | 'semi' | 'comma';
interface BaseConfig {
    delimiter ?: Delimiter
    requireLast ?: boolean
    singleLine ?: Delimiter
}
type Config = BaseConfig & {
    overrides ?: {
        interface ?: BaseConfig
        typeLiteral ?: BaseConfig
    }
}
```
After:
```ts
type Delimiter = 'none' | 'semi' | 'comma';
interface BaseConfig {
    multiline ?: {
        delimiter ?: 'none' | 'semi' | 'comma'
        requireLast ?: boolean
    }
    singleline ?: {
        delimiter ?: 'semi' | 'comma'
        requireLast ?: boolean
    }
}
type Config = BaseConfig & {
    overrides ?: {
        interface ?: BaseConfig
        typeLiteral ?: BaseConfig
    }
}
```