### PR TITLE
[CHORE] Add yarn check to precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint && yarn test && yarn docs:check && lint-staged"
+      "pre-commit": "yarn check --verify-tree && yarn lint && yarn format-check && yarn test && yarn docs:check && lint-staged"
     }
   },
   "engines": {


### PR DESCRIPTION
https://yarnpkg.com/lang/en/docs/cli/check/#toc-yarn-check-verify-tree

`yarn check` will ensure that your dependencies are up-to-date before committing.

This ensures that when you raise a PR, travis will not fail due to an error introduced in a new version of a tool.