### PR TITLE
[FEAT] [indent] Extend the base rule to support TS nodes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,13 +12,16 @@
         "plugin:eslint-plugin/recommended"
     ],
     "rules": {
+        "new-cap": "off",
+        "lines-around-comment": "off",
+
         "prettier/prettier": [
             "error",
             {
                 "tabWidth": 4
             }
         ],
-        "lines-around-comment": "off",
+
         "eslint-plugin/prefer-placeholders": "error",
         "eslint-plugin/prefer-replace-text": "error",
         "eslint-plugin/no-deprecated-report-api": "error"

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Rule to flag non-camelcased identifiers
+ * @author Patricio Trevino
+ */
+"use strict";
+
+const baseRule = require("eslint/lib/rules/indent");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const KNOWN_NODES = new Set([
+    // ts specific nodes we want to support
+    "TSTypeLiteral",
+    "TSPropertySignature",
+]);
+
+module.exports = Object.assign({}, baseRule, {
+    create(context) {
+        const rules = baseRule.create(context);
+
+        /**
+         * Converts from a TSPropertySignature to a Property
+         * @param {Object} node a TSPropertySignature node
+         * @returns {Object} a Property node
+         */
+        function TSPropertySignatureToProperty(node) {
+            return {
+                type: "Property",
+                key: node.key,
+                value: node.typeAnnotation,
+
+                // Property flags
+                computed: false,
+                method: false,
+                kind: "init",
+                // this will stop eslint from interrogating the type literal
+                shorthand: true,
+
+                // location data
+                range: node.range,
+                loc: node.loc,
+            };
+        }
+
+        return Object.assign({}, rules, {
+            // overwrite the base rule here so we can use our KNOWN_NODES list instead
+            "*:exit"(node) {
+                // For nodes we care about, skip the default handling, because it just marks the node as ignored...
+                if (!KNOWN_NODES.has(node.type)) {
+                    rules["*:exit"](node);
+                }
+            },
+
+            TSTypeLiteral(node) {
+                // transform it to an ObjectExpression so the indent rule can understand it
+                return rules["ObjectExpression, ObjectPattern"]({
+                    type: "ObjectExpression",
+                    properties: node.members.map(TSPropertySignatureToProperty),
+
+                    // location data
+                    range: node.range,
+                    loc: node.loc,
+                });
+            },
+
+            // specifically use TSInterfaceBody instead of TSInterfaceDeclaration,
+            // because it matches ObjectExpression (i.e. is curly brace to curly brace)
+            TSInterfaceBody(node) {
+                return rules["ObjectExpression, ObjectPattern"]({
+                    type: "ObjectExpression",
+                    properties: node.body.map(TSPropertySignatureToProperty),
+
+                    // location data
+                    range: node.range,
+                    loc: node.loc,
+                });
+            },
+        });
+    },
+});

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("eslint/lib/rules/indent"),
+const rule = require("../../../lib/rules/indent"),
     RuleTester = require("eslint").RuleTester;
 
 const ruleTester = new RuleTester({
@@ -21,57 +21,223 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run("indent", rule, {
-    valid: [
-        `
-@Component({
-    components: {
-        ErrorPage: () => import('@/components/ErrorPage.vue'),
-    },
-    head: {
-        titleTemplate(title) {
-            if (title) {
-                return \`test\`
-            }
-            return 'Title'
-        },
-        htmlAttrs: {
-            lang: 'en',
-        },
-        meta: [
-            { charset: 'utf-8' },
-            { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        ],
-    },
-})
-export default class App extends Vue 
-{
-    get error() 
-    {
-        return this.$store.state.errorHandler.error
-    }
+    valid: [],
+    invalid: [
+        {
+            code: `
+type Foo = {
+bar : string,
+age : number,
 }
-        `,
-        // https://github.com/eslint/typescript-eslint-parser/issues/474
-        `
-/**
- * @param {string} name
- * @param {number} age
- * @returns {string}
- */
-function foo(name: string, age: number): string {}
-        `,
-        `
-const firebaseApp = firebase.apps.length
-    ? firebase.app()
-    : firebase.initializeApp({
-        apiKey: __FIREBASE_API_KEY__,
-        authDomain: __FIREBASE_AUTH_DOMAIN__,
-        databaseURL: __FIREBASE_DATABASE_URL__,
-        projectId: __FIREBASE_PROJECT_ID__,
-        storageBucket: __FIREBASE_STORAGE_BUCKET__,
-        messagingSenderId: __FIREBASE_MESSAGING_SENDER_ID__,
-    })
-        `,
+            `,
+            output: `
+type Foo = {
+    bar : string,
+    age : number,
+}
+            `,
+            errors: [
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 3,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 4,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+bar : string,
+age : number,
+}
+            `,
+            output: `
+interface Foo {
+    bar : string,
+    age : number,
+}
+            `,
+            errors: [
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 3,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 4,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `
+interface Foo {
+bar : {
+baz : string,
+},
+age : number,
+}
+            `,
+            output: `
+interface Foo {
+    bar : {
+        baz : string,
+    },
+    age : number,
+}
+            `,
+            errors: [
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 3,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 8 spaces but found 0.`,
+                    line: 4,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 5,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 6,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `
+const foo : Foo<{
+bar : string,
+age : number,
+}>
+            `,
+            output: `
+const foo : Foo<{
+    bar : string,
+    age : number,
+}>
+            `,
+            errors: [
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 3,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 4,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `
+type T = {
+bar : string,
+age : number,
+} | {
+bar : string,
+age : number,
+}
+            `,
+            output: `
+type T = {
+    bar : string,
+    age : number,
+} | {
+    bar : string,
+    age : number,
+}
+            `,
+            errors: [
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 3,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 4,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 6,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 7,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `
+type T =
+    | {
+bar : string,
+age : number,
+}
+    | {
+    bar : string,
+    age : number,
+}
+            `,
+            output: `
+type T =
+    | {
+        bar : string,
+        age : number,
+    }
+    | {
+        bar : string,
+        age : number,
+    }
+            `,
+            errors: [
+                {
+                    message: `Expected indentation of 8 spaces but found 0.`,
+                    line: 4,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 8 spaces but found 0.`,
+                    line: 5,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 6,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 8 spaces but found 4.`,
+                    line: 8,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 8 spaces but found 4.`,
+                    line: 9,
+                    column: 1,
+                },
+                {
+                    message: `Expected indentation of 4 spaces but found 0.`,
+                    line: 10,
+                    column: 1,
+                },
+            ],
+        },
     ],
-    invalid: [],
 });


### PR DESCRIPTION
Fixes #201 

The [base eslint implementation](https://github.com/eslint/eslint/blob/master/lib/rules/indent.js) purposely ignores nodes it doesn't know about (i.e. our TS nodes).

Because of how the base rule is written, we have to override the implementation entirely.