### PR TITLE
chore: enable report-message-format and fix all messages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
         "lines-around-comment": "off",
         "eslint-plugin/prefer-placeholders": "error",
         "eslint-plugin/prefer-replace-text": "error",
-        "eslint-plugin/no-deprecated-report-api": "error"
+        "eslint-plugin/no-deprecated-report-api": "error",
+        "eslint-plugin/report-message-format": ["error", "^[A-Z'{].*[\\.}]$"]
     }
 }

--- a/lib/rules/adjacent-overload-signatures.js
+++ b/lib/rules/adjacent-overload-signatures.js
@@ -93,7 +93,7 @@ module.exports = {
                         context.report({
                             node: member,
                             message:
-                                "All '{{name}}' signatures should be adjacent",
+                                "All '{{name}}' signatures should be adjacent.",
                             data: {
                                 name,
                             },

--- a/lib/rules/class-name-casing.js
+++ b/lib/rules/class-name-casing.js
@@ -67,7 +67,7 @@ module.exports = {
 
             context.report({
                 node: resolvedId,
-                message: "{{friendlyName}} '{{name}}' must be PascalCased",
+                message: "{{friendlyName}} '{{name}}' must be PascalCased.",
                 data: {
                     friendlyName,
                     name: resolvedId.name,

--- a/lib/rules/generic-type-naming.js
+++ b/lib/rules/generic-type-naming.js
@@ -29,8 +29,7 @@ function createTypeParameterChecker(context, rule) {
 
                     context.report({
                         node,
-                        message:
-                            "Type parameter {{name}} does not match rule {{rule}}",
+                        messageId: "paramNotMatchRule",
                         data,
                     });
                 }
@@ -46,6 +45,10 @@ module.exports = {
             category: "TypeScript",
             url:
                 "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/generic-type-naming.md",
+        },
+        messages: {
+            paramNotMatchRule:
+                "Type parameter {{name}} does not match rule {{rule}}.",
         },
     },
 

--- a/lib/rules/interface-name-prefix.js
+++ b/lib/rules/interface-name-prefix.js
@@ -58,14 +58,15 @@ module.exports = {
                 if (isPrefixedWithI(interfaceNode.id.name)) {
                     context.report({
                         node: interfaceNode.id,
-                        message: 'Interface name must not be prefixed with "I"',
+                        message:
+                            'Interface name must not be prefixed with "I".',
                     });
                 }
             } else {
                 if (!isPrefixedWithI(interfaceNode.id.name)) {
                     context.report({
                         node: interfaceNode.id,
-                        message: 'Interface name must be prefixed with "I"',
+                        message: 'Interface name must be prefixed with "I".',
                     });
                 }
             }

--- a/lib/rules/member-naming.js
+++ b/lib/rules/member-naming.js
@@ -59,7 +59,7 @@ module.exports = {
             context.report({
                 node: node.key,
                 message:
-                    "{{accessibility}} property {{name}} should match {{convention}}",
+                    "{{accessibility}} property {{name}} should match {{convention}}.",
                 data: { accessibility, name, convention },
             });
         }

--- a/lib/rules/no-angle-bracket-type-assertion.js
+++ b/lib/rules/no-angle-bracket-type-assertion.js
@@ -36,7 +36,7 @@ module.exports = {
                 context.report({
                     node,
                     message:
-                        "Prefer 'as {{cast}}' instead of '<{{cast}}>' when doing type assertions",
+                        "Prefer 'as {{cast}}' instead of '<{{cast}}>' when doing type assertions.",
                     data: {
                         cast: sourceCode.getText(
                             node.typeAnnotation.typeAnnotation

--- a/lib/rules/no-empty-interface.js
+++ b/lib/rules/no-empty-interface.js
@@ -36,7 +36,7 @@ module.exports = {
                         node: node.id,
                         message:
                             heritage === 0
-                                ? "An empty interface is equivalent to `{}`"
+                                ? "An empty interface is equivalent to `{}`."
                                 : "An interface declaring no members is equivalent to its supertype.",
                     });
                 }

--- a/lib/rules/no-inferrable-types.js
+++ b/lib/rules/no-inferrable-types.js
@@ -123,7 +123,7 @@ module.exports = {
             context.report({
                 node,
                 message:
-                    "Type {{type}} trivially inferred from a {{type}} literal, remove type annotation",
+                    "Type {{type}} trivially inferred from a {{type}} literal, remove type annotation.",
                 data: {
                     type,
                 },

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -97,7 +97,7 @@ module.exports = {
                 context.report({
                     node,
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                 });
             },
         };

--- a/lib/rules/no-non-null-assertion.js
+++ b/lib/rules/no-non-null-assertion.js
@@ -31,7 +31,7 @@ module.exports = {
             TSNonNullExpression(node) {
                 context.report({
                     node,
-                    message: "Forbidden non-null assertion",
+                    message: "Forbidden non-null assertion.",
                 });
             },
         };

--- a/lib/rules/no-parameter-properties.js
+++ b/lib/rules/no-parameter-properties.js
@@ -81,7 +81,7 @@ module.exports = {
                     context.report({
                         node,
                         message:
-                            "Property {{parameter}} cannot be declared in the constructor",
+                            "Property {{parameter}} cannot be declared in the constructor.",
                         data: {
                             parameter: node.parameter.name,
                         },

--- a/lib/rules/no-triple-slash-reference.js
+++ b/lib/rules/no-triple-slash-reference.js
@@ -46,7 +46,7 @@ module.exports = {
                 if (referenceRegExp.test(comment.value)) {
                     context.report({
                         node: comment,
-                        message: "Do not use a triple slash reference",
+                        message: "Do not use a triple slash reference.",
                     });
                 }
             });

--- a/lib/rules/no-type-alias.js
+++ b/lib/rules/no-type-alias.js
@@ -191,17 +191,17 @@ module.exports = {
         function getMessage(compositionType, isRoot, type) {
             if (isRoot) {
                 return type
-                    ? `Type ${type} are not allowed`
-                    : "Type aliases are not allowed";
+                    ? `Type ${type} are not allowed.`
+                    : "Type aliases are not allowed.";
             }
 
             return compositionType === "TSUnionType"
                 ? `${type[0].toUpperCase()}${type.slice(
                       1
-                  )} in union types are not allowed`
+                  )} in union types are not allowed.`
                 : `${type[0].toUpperCase()}${type.slice(
                       1
-                  )} in intersection types are not allowed`;
+                  )} in intersection types are not allowed.`;
         }
 
         /**

--- a/lib/rules/no-var-requires.js
+++ b/lib/rules/no-var-requires.js
@@ -36,7 +36,7 @@ module.exports = {
                     context.report({
                         node,
                         message:
-                            "Require statement not part of import statement",
+                            "Require statement not part of import statement.",
                     });
                 }
             },

--- a/lib/rules/prefer-namespace-keyword.js
+++ b/lib/rules/prefer-namespace-keyword.js
@@ -48,7 +48,7 @@ module.exports = {
                     context.report({
                         node,
                         message:
-                            "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
+                            "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
                         fix(fixer) {
                             return fixer.replaceText(moduleType, "namespace");
                         },

--- a/lib/rules/type-annotation-spacing.js
+++ b/lib/rules/type-annotation-spacing.js
@@ -117,7 +117,7 @@ module.exports = {
             if (after && nextDelta === 0) {
                 context.report({
                     node: punctuatorTokenEnd,
-                    message: "Expected a space after the '{{type}}'",
+                    message: "Expected a space after the '{{type}}'.",
                     data: {
                         type,
                     },
@@ -128,7 +128,7 @@ module.exports = {
             } else if (!after && nextDelta > 0) {
                 context.report({
                     node: punctuatorTokenEnd,
-                    message: "Unexpected space after the '{{type}}'",
+                    message: "Unexpected space after the '{{type}}'.",
                     data: {
                         type,
                     },
@@ -144,7 +144,7 @@ module.exports = {
             if (before && previousDelta === 0) {
                 context.report({
                     node: punctuatorTokenStart,
-                    message: "Expected a space before the '{{type}}'",
+                    message: "Expected a space before the '{{type}}'.",
                     data: {
                         type,
                     },
@@ -155,7 +155,7 @@ module.exports = {
             } else if (!before && previousDelta > 0) {
                 context.report({
                     node: punctuatorTokenStart,
-                    message: "Unexpected space before the '{{type}}'",
+                    message: "Unexpected space before the '{{type}}'.",
                     data: {
                         type,
                     },

--- a/tests/lib/rules/adjacent-overload-signatures.js
+++ b/tests/lib/rules/adjacent-overload-signatures.js
@@ -228,7 +228,7 @@ export function foo(sn: string | number) {}
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -244,7 +244,7 @@ export function foo(sn: string | number) {}
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -260,7 +260,7 @@ function foo(sn: string | number) {}
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -276,7 +276,7 @@ function foo(sn: string | number) {}
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -292,7 +292,7 @@ function foo(sn: string | number) {}
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -307,7 +307,7 @@ function foo(sn: string | number) {}
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 5,
                     column: 1,
                 },
@@ -327,7 +327,7 @@ class Bar {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 9,
                     column: 5,
                 },
@@ -343,7 +343,7 @@ declare function foo(sn: string | number);
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -359,7 +359,7 @@ declare function foo(sn: string | number);
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 6,
                     column: 1,
                 },
@@ -377,7 +377,7 @@ declare module "Foo" {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -397,7 +397,7 @@ declare module "Foo" {
             `,
             errors: [
                 {
-                    message: "All 'baz' signatures should be adjacent",
+                    message: "All 'baz' signatures should be adjacent.",
                     line: 8,
                     column: 5,
                 },
@@ -415,7 +415,7 @@ declare namespace Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -435,7 +435,7 @@ declare namespace Foo {
             `,
             errors: [
                 {
-                    message: "All 'baz' signatures should be adjacent",
+                    message: "All 'baz' signatures should be adjacent.",
                     line: 8,
                     column: 5,
                 },
@@ -453,7 +453,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -471,7 +471,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -490,7 +490,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 5,
                     column: 5,
                 },
@@ -509,7 +509,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'call' signatures should be adjacent",
+                    message: "All 'call' signatures should be adjacent.",
                     line: 5,
                     column: 5,
                 },
@@ -527,7 +527,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -545,7 +545,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -563,7 +563,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -582,7 +582,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 5,
                     column: 5,
                 },
@@ -602,7 +602,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'baz' signatures should be adjacent",
+                    message: "All 'baz' signatures should be adjacent.",
                     line: 8,
                     column: 9,
                 },
@@ -620,7 +620,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'new' signatures should be adjacent",
+                    message: "All 'new' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -638,12 +638,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "All 'new' signatures should be adjacent",
+                    message: "All 'new' signatures should be adjacent.",
                     line: 5,
                     column: 5,
                 },
                 {
-                    message: "All 'new' signatures should be adjacent",
+                    message: "All 'new' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -661,7 +661,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "All 'constructor' signatures should be adjacent",
+                    message: "All 'constructor' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -679,7 +679,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -697,7 +697,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -715,7 +715,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 7,
                     column: 5,
                 },
@@ -734,7 +734,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "All 'constructor' signatures should be adjacent",
+                    message: "All 'constructor' signatures should be adjacent.",
                     line: 5,
                     column: 5,
                 },
@@ -753,7 +753,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "All 'foo' signatures should be adjacent",
+                    message: "All 'foo' signatures should be adjacent.",
                     line: 5,
                     column: 5,
                 },

--- a/tests/lib/rules/class-name-casing.js
+++ b/tests/lib/rules/class-name-casing.js
@@ -41,7 +41,7 @@ ruleTester.run("class-name-casing", rule, {
             code: "class invalidClassName {}",
             errors: [
                 {
-                    message: "Class 'invalidClassName' must be PascalCased",
+                    message: "Class 'invalidClassName' must be PascalCased.",
                     line: 1,
                     column: 7,
                 },
@@ -52,7 +52,7 @@ ruleTester.run("class-name-casing", rule, {
             errors: [
                 {
                     message:
-                        "Class 'Another_Invalid_Class_Name' must be PascalCased",
+                        "Class 'Another_Invalid_Class_Name' must be PascalCased.",
                     line: 1,
                     column: 7,
                 },
@@ -62,7 +62,7 @@ ruleTester.run("class-name-casing", rule, {
             code: "var foo = class {};",
             errors: [
                 {
-                    message: "Class 'foo' must be PascalCased",
+                    message: "Class 'foo' must be PascalCased.",
                     line: 1,
                     column: 5,
                 },
@@ -72,7 +72,7 @@ ruleTester.run("class-name-casing", rule, {
             code: "const foo = class {};",
             errors: [
                 {
-                    message: "Class 'foo' must be PascalCased",
+                    message: "Class 'foo' must be PascalCased.",
                     line: 1,
                     column: 7,
                 },
@@ -82,7 +82,7 @@ ruleTester.run("class-name-casing", rule, {
             code: "var bar = class invalidName {}",
             errors: [
                 {
-                    message: "Class 'invalidName' must be PascalCased",
+                    message: "Class 'invalidName' must be PascalCased.",
                     line: 1,
                     column: 17,
                 },
@@ -92,7 +92,7 @@ ruleTester.run("class-name-casing", rule, {
             code: "interface someInterface {}",
             errors: [
                 {
-                    message: "Interface 'someInterface' must be PascalCased",
+                    message: "Interface 'someInterface' must be PascalCased.",
                     line: 1,
                     column: 11,
                 },
@@ -103,7 +103,7 @@ ruleTester.run("class-name-casing", rule, {
             errors: [
                 {
                     message:
-                        "Abstract class 'invalidClassName' must be PascalCased",
+                        "Abstract class 'invalidClassName' must be PascalCased.",
                     line: 1,
                     column: 16,
                 },
@@ -113,7 +113,7 @@ ruleTester.run("class-name-casing", rule, {
             code: "declare class invalidClassName {}",
             errors: [
                 {
-                    message: "Class 'invalidClassName' must be PascalCased",
+                    message: "Class 'invalidClassName' must be PascalCased.",
                     line: 1,
                     column: 15,
                 },

--- a/tests/lib/rules/generic-type-naming.js
+++ b/tests/lib/rules/generic-type-naming.js
@@ -15,22 +15,6 @@ const ruleTester = new RuleTester({
     parser: "typescript-eslint-parser",
 });
 
-const messagePattern = "Type parameter {{name}} does not match rule {{rule}}";
-
-/**
- * Creates error object
- * @param {Object} data Data
- * @returns {Object} Object with message property
- */
-function error(data) {
-    let message = messagePattern;
-
-    Object.keys(data).forEach(key => {
-        message = message.replace(new RegExp(`{{${key}}}`, "g"), data[key]);
-    });
-    return { message };
-}
-
 ruleTester.run("generic-type-naming", rule, {
     valid: [
         { code: "class<T,U,V> { }", options: [] },
@@ -48,27 +32,52 @@ ruleTester.run("generic-type-naming", rule, {
         {
             code: "class<x> { }",
             options: ["^[A-Z]+$"],
-            errors: [error({ name: "x", rule: "^[A-Z]+$" })],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "x", rule: "^[A-Z]+$" },
+                },
+            ],
         },
         {
             code: "interface SimpleMap<x> { }",
             options: ["^[A-Z]+$"],
-            errors: [error({ name: "x", rule: "^[A-Z]+$" })],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "x", rule: "^[A-Z]+$" },
+                },
+            ],
         },
         {
             code: "type R<x> = {}",
             options: ["^[A-Z]+$"],
-            errors: [error({ name: "x", rule: "^[A-Z]+$" })],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "x", rule: "^[A-Z]+$" },
+                },
+            ],
         },
         {
             code: "function get<x>() {}",
             options: ["^[A-Z]+$"],
-            errors: [error({ name: "x", rule: "^[A-Z]+$" })],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "x", rule: "^[A-Z]+$" },
+                },
+            ],
         },
         {
             code: "interface GenericIdentityFn { <x>(arg: x): x }",
             options: ["^[A-Z]+$"],
-            errors: [error({ name: "x", rule: "^[A-Z]+$" })],
+            errors: [
+                {
+                    messageId: "paramNotMatchRule",
+                    data: { name: "x", rule: "^[A-Z]+$" },
+                },
+            ],
         },
     ],
 });

--- a/tests/lib/rules/interface-name-prefix.js
+++ b/tests/lib/rules/interface-name-prefix.js
@@ -76,7 +76,7 @@ interface IAnimal {
             `,
             errors: [
                 {
-                    message: 'Interface name must not be prefixed with "I"',
+                    message: 'Interface name must not be prefixed with "I".',
                     line: 2,
                     column: 11,
                 },
@@ -91,7 +91,7 @@ interface Animal {
             options: ["always"],
             errors: [
                 {
-                    message: 'Interface name must be prefixed with "I"',
+                    message: 'Interface name must be prefixed with "I".',
                     line: 2,
                     column: 11,
                 },
@@ -106,7 +106,7 @@ interface Iguana {
             options: ["always"],
             errors: [
                 {
-                    message: 'Interface name must be prefixed with "I"',
+                    message: 'Interface name must be prefixed with "I".',
                     line: 2,
                     column: 11,
                 },
@@ -121,7 +121,7 @@ interface IIguana {
             options: ["never"],
             errors: [
                 {
-                    message: 'Interface name must not be prefixed with "I"',
+                    message: 'Interface name must not be prefixed with "I".',
                     line: 2,
                     column: 11,
                 },
@@ -136,7 +136,7 @@ interface IAnimal {
             options: ["never"],
             errors: [
                 {
-                    message: 'Interface name must not be prefixed with "I"',
+                    message: 'Interface name must not be prefixed with "I".',
                     line: 2,
                     column: 11,
                 },

--- a/tests/lib/rules/member-naming.js
+++ b/tests/lib/rules/member-naming.js
@@ -99,7 +99,7 @@ class Class {
             options: [{ public: "^_" }],
             errors: [
                 {
-                    message: "public property fooBar should match /^_/",
+                    message: "public property fooBar should match /^_/.",
                     line: 1,
                     column: 15,
                 },
@@ -110,7 +110,7 @@ class Class {
             options: [{ public: "^_" }],
             errors: [
                 {
-                    message: "public property fooBar should match /^_/",
+                    message: "public property fooBar should match /^_/.",
                     line: 1,
                     column: 22,
                 },
@@ -121,7 +121,7 @@ class Class {
             options: [{ protected: "^_" }],
             errors: [
                 {
-                    message: "protected property fooBar should match /^_/",
+                    message: "protected property fooBar should match /^_/.",
                     line: 1,
                     column: 25,
                 },
@@ -132,7 +132,7 @@ class Class {
             options: [{ private: "^_" }],
             errors: [
                 {
-                    message: "private property fooBar should match /^_/",
+                    message: "private property fooBar should match /^_/.",
                     line: 1,
                     column: 23,
                 },
@@ -156,23 +156,23 @@ class Class {
             ],
             errors: [
                 {
-                    message: "public property one should match /^pub[A-Z]/",
+                    message: "public property one should match /^pub[A-Z]/.",
                     line: 3,
                     column: 5,
                 },
                 {
-                    message: "public property two should match /^pub[A-Z]/",
+                    message: "public property two should match /^pub[A-Z]/.",
                     line: 4,
                     column: 12,
                 },
                 {
                     message:
-                        "protected property three should match /^prot[A-Z]/",
+                        "protected property three should match /^prot[A-Z]/.",
                     line: 5,
                     column: 15,
                 },
                 {
-                    message: "private property four should match /^priv[A-Z]/",
+                    message: "private property four should match /^priv[A-Z]/.",
                     line: 6,
                     column: 13,
                 },
@@ -196,23 +196,23 @@ class Class {
             ],
             errors: [
                 {
-                    message: "public property one should match /^pub[A-Z]/",
+                    message: "public property one should match /^pub[A-Z]/.",
                     line: 3,
                     column: 5,
                 },
                 {
-                    message: "public property two should match /^pub[A-Z]/",
+                    message: "public property two should match /^pub[A-Z]/.",
                     line: 4,
                     column: 12,
                 },
                 {
                     message:
-                        "protected property three should match /^prot[A-Z]/",
+                        "protected property three should match /^prot[A-Z]/.",
                     line: 5,
                     column: 15,
                 },
                 {
-                    message: "private property four should match /^priv[A-Z]/",
+                    message: "private property four should match /^priv[A-Z]/.",
                     line: 6,
                     column: 13,
                 },
@@ -236,23 +236,23 @@ class Class {
             ],
             errors: [
                 {
-                    message: "public property one should match /^pub[A-Z]/",
+                    message: "public property one should match /^pub[A-Z]/.",
                     line: 3,
                     column: 5,
                 },
                 {
-                    message: "public property two should match /^pub[A-Z]/",
+                    message: "public property two should match /^pub[A-Z]/.",
                     line: 4,
                     column: 12,
                 },
                 {
                     message:
-                        "protected property three should match /^prot[A-Z]/",
+                        "protected property three should match /^prot[A-Z]/.",
                     line: 5,
                     column: 15,
                 },
                 {
-                    message: "private property four should match /^priv[A-Z]/",
+                    message: "private property four should match /^priv[A-Z]/.",
                     line: 6,
                     column: 13,
                 },

--- a/tests/lib/rules/no-angle-bracket-type-assertion.js
+++ b/tests/lib/rules/no-angle-bracket-type-assertion.js
@@ -74,13 +74,13 @@ const bar = <Foo>new Generic<int>();
             errors: [
                 {
                     message:
-                        "Prefer 'as Foo' instead of '<Foo>' when doing type assertions",
+                        "Prefer 'as Foo' instead of '<Foo>' when doing type assertions.",
                     row: 8,
                     column: 13,
                 },
                 {
                     message:
-                        "Prefer 'as Foo' instead of '<Foo>' when doing type assertions",
+                        "Prefer 'as Foo' instead of '<Foo>' when doing type assertions.",
                     row: 9,
                     column: 13,
                 },
@@ -91,7 +91,7 @@ const bar = <Foo>new Generic<int>();
             errors: [
                 {
                     message:
-                        "Prefer 'as number' instead of '<number>' when doing type assertions",
+                        "Prefer 'as number' instead of '<number>' when doing type assertions.",
                     row: 1,
                     column: 20,
                 },
@@ -105,7 +105,7 @@ const b : number = <number>a;
             errors: [
                 {
                     message:
-                        "Prefer 'as number' instead of '<number>' when doing type assertions",
+                        "Prefer 'as number' instead of '<number>' when doing type assertions.",
                     row: 3,
                     column: 20,
                 },
@@ -116,7 +116,7 @@ const b : number = <number>a;
             errors: [
                 {
                     message:
-                        "Prefer 'as Array<number>' instead of '<Array<number>>' when doing type assertions",
+                        "Prefer 'as Array<number>' instead of '<Array<number>>' when doing type assertions.",
                     row: 1,
                     column: 27,
                 },
@@ -133,7 +133,7 @@ const a : A = <A>b;
             errors: [
                 {
                     message:
-                        "Prefer 'as A' instead of '<A>' when doing type assertions",
+                        "Prefer 'as A' instead of '<A>' when doing type assertions.",
                     row: 6,
                     column: 15,
                 },
@@ -154,7 +154,7 @@ const a: A = <A>b;
             errors: [
                 {
                     message:
-                        "Prefer 'as A' instead of '<A>' when doing type assertions",
+                        "Prefer 'as A' instead of '<A>' when doing type assertions.",
                     row: 9,
                     column: 14,
                 },

--- a/tests/lib/rules/no-empty-interface.js
+++ b/tests/lib/rules/no-empty-interface.js
@@ -44,7 +44,7 @@ interface Baz extends Foo, Bar {}
             code: "interface Foo {}",
             errors: [
                 {
-                    message: "An empty interface is equivalent to `{}`",
+                    message: "An empty interface is equivalent to `{}`.",
                     line: 1,
                     column: 11,
                 },
@@ -54,7 +54,7 @@ interface Baz extends Foo, Bar {}
             code: "interface Foo extends {}",
             errors: [
                 {
-                    message: "An empty interface is equivalent to `{}`",
+                    message: "An empty interface is equivalent to `{}`.",
                     line: 1,
                     column: 11,
                 },

--- a/tests/lib/rules/no-inferrable-types.js
+++ b/tests/lib/rules/no-inferrable-types.js
@@ -65,7 +65,7 @@ ruleTester.run("no-inferrable-types", rule, {
             errors: [
                 {
                     message:
-                        "Type number trivially inferred from a number literal, remove type annotation",
+                        "Type number trivially inferred from a number literal, remove type annotation.",
                     line: 1,
                     column: 7,
                 },
@@ -77,7 +77,7 @@ ruleTester.run("no-inferrable-types", rule, {
             errors: [
                 {
                     message:
-                        "Type number trivially inferred from a number literal, remove type annotation",
+                        "Type number trivially inferred from a number literal, remove type annotation.",
                     line: 1,
                     column: 7,
                 },
@@ -89,7 +89,7 @@ ruleTester.run("no-inferrable-types", rule, {
             errors: [
                 {
                     message:
-                        "Type boolean trivially inferred from a boolean literal, remove type annotation",
+                        "Type boolean trivially inferred from a boolean literal, remove type annotation.",
                     line: 1,
                     column: 7,
                 },
@@ -101,7 +101,7 @@ ruleTester.run("no-inferrable-types", rule, {
             errors: [
                 {
                     message:
-                        "Type string trivially inferred from a string literal, remove type annotation",
+                        "Type string trivially inferred from a string literal, remove type annotation.",
                     line: 1,
                     column: 7,
                 },
@@ -114,19 +114,19 @@ ruleTester.run("no-inferrable-types", rule, {
             errors: [
                 {
                     message:
-                        "Type number trivially inferred from a number literal, remove type annotation",
+                        "Type number trivially inferred from a number literal, remove type annotation.",
                     line: 1,
                     column: 13,
                 },
                 {
                     message:
-                        "Type boolean trivially inferred from a boolean literal, remove type annotation",
+                        "Type boolean trivially inferred from a boolean literal, remove type annotation.",
                     line: 1,
                     column: 28,
                 },
                 {
                     message:
-                        "Type string trivially inferred from a string literal, remove type annotation",
+                        "Type string trivially inferred from a string literal, remove type annotation.",
                     line: 1,
                     column: 47,
                 },
@@ -139,19 +139,19 @@ ruleTester.run("no-inferrable-types", rule, {
             errors: [
                 {
                     message:
-                        "Type number trivially inferred from a number literal, remove type annotation",
+                        "Type number trivially inferred from a number literal, remove type annotation.",
                     line: 1,
                     column: 13,
                 },
                 {
                     message:
-                        "Type boolean trivially inferred from a boolean literal, remove type annotation",
+                        "Type boolean trivially inferred from a boolean literal, remove type annotation.",
                     line: 1,
                     column: 28,
                 },
                 {
                     message:
-                        "Type string trivially inferred from a string literal, remove type annotation",
+                        "Type string trivially inferred from a string literal, remove type annotation.",
                     line: 1,
                     column: 47,
                 },

--- a/tests/lib/rules/no-namespace.js
+++ b/tests/lib/rules/no-namespace.js
@@ -38,7 +38,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -49,7 +49,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -61,7 +61,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -73,7 +73,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -84,7 +84,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -95,7 +95,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -107,7 +107,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },
@@ -119,7 +119,7 @@ ruleTester.run("no-namespace", rule, {
             errors: [
                 {
                     message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces",
+                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
                     row: 1,
                     column: 1,
                 },

--- a/tests/lib/rules/no-non-null-assertion.js
+++ b/tests/lib/rules/no-non-null-assertion.js
@@ -26,7 +26,7 @@ ruleTester.run("no-non-null-assertion", rule, {
             code: "const x = null; x!.y;",
             errors: [
                 {
-                    message: "Forbidden non-null assertion",
+                    message: "Forbidden non-null assertion.",
                     line: 1,
                     column: 17,
                 },

--- a/tests/lib/rules/no-parameter-properties.js
+++ b/tests/lib/rules/no-parameter-properties.js
@@ -120,7 +120,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -135,7 +135,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -150,7 +150,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -165,7 +165,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -180,7 +180,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -195,7 +195,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -210,7 +210,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -225,7 +225,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -240,13 +240,13 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 3,
                     column: 39,
                 },
@@ -261,13 +261,13 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 3,
                     column: 41,
                 },
@@ -282,13 +282,13 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 3,
                     column: 38,
                 },
@@ -304,7 +304,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
@@ -320,13 +320,13 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
@@ -342,19 +342,19 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 4,
                     column: 39,
                 },
@@ -370,7 +370,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
@@ -386,13 +386,13 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
@@ -408,19 +408,19 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 4,
                     column: 41,
                 },
@@ -436,7 +436,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
@@ -452,13 +452,13 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
@@ -474,19 +474,19 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 4,
                     column: 17,
                 },
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 4,
                     column: 38,
                 },
@@ -503,7 +503,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -519,7 +519,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -544,7 +544,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -570,7 +570,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -586,7 +586,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -611,7 +611,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property name cannot be declared in the constructor",
+                        "Property name cannot be declared in the constructor.",
                     line: 3,
                     column: 17,
                 },
@@ -628,7 +628,7 @@ class Foo {
             errors: [
                 {
                     message:
-                        "Property age cannot be declared in the constructor",
+                        "Property age cannot be declared in the constructor.",
                     line: 4,
                     column: 39,
                 },

--- a/tests/lib/rules/no-triple-slash-reference.js
+++ b/tests/lib/rules/no-triple-slash-reference.js
@@ -29,7 +29,7 @@ ruleTester.run("no-triple-slash-reference", rule, {
             code: '/// <reference path="Animal" />',
             errors: [
                 {
-                    message: "Do not use a triple slash reference",
+                    message: "Do not use a triple slash reference.",
                     line: 1,
                     column: 1,
                 },
@@ -43,7 +43,7 @@ let a
             parser: "typescript-eslint-parser",
             errors: [
                 {
-                    message: "Do not use a triple slash reference",
+                    message: "Do not use a triple slash reference.",
                     line: 2,
                     column: 1,
                 },

--- a/tests/lib/rules/no-type-alias.js
+++ b/tests/lib/rules/no-type-alias.js
@@ -514,7 +514,7 @@ type Foo<T> = {
             code: "type Foo = 'a'",
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -525,7 +525,7 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -536,7 +536,7 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -546,12 +546,12 @@ type Foo<T> = {
             code: "type Foo = 'a' | 'b';",
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -562,12 +562,12 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -578,12 +578,12 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -594,12 +594,12 @@ type Foo<T> = {
             options: [{ allowAliases: false, allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -610,12 +610,12 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -626,12 +626,12 @@ type Foo<T> = {
             options: [{ allowAliases: "never", allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -647,12 +647,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -662,17 +662,17 @@ type Foo<T> = {
             code: "type Foo = 'a' | 'b' | 'c';",
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -683,17 +683,17 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -704,17 +704,17 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -725,17 +725,17 @@ type Foo<T> = {
             options: [{ allowAliases: false, allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -746,17 +746,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -767,17 +767,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never", allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -788,17 +788,17 @@ type Foo<T> = {
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -814,17 +814,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -834,12 +834,12 @@ type Foo<T> = {
             code: "type Foo = 'a' & 'b';",
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -850,12 +850,12 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -866,12 +866,12 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -884,12 +884,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -900,12 +900,12 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -918,12 +918,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -934,12 +934,12 @@ type Foo<T> = {
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -955,12 +955,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -970,17 +970,17 @@ type Foo<T> = {
             code: "type Foo = 'a' & 'b' & 'c';",
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -991,17 +991,17 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1012,17 +1012,17 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1035,17 +1035,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1056,17 +1056,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1079,17 +1079,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1100,17 +1100,17 @@ type Foo<T> = {
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1126,17 +1126,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1146,17 +1146,17 @@ type Foo<T> = {
             code: "type Foo = 'a' | 'b' & 'c';",
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1167,17 +1167,17 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1188,17 +1188,17 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1211,17 +1211,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1232,17 +1232,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1255,17 +1255,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1276,12 +1276,12 @@ type Foo<T> = {
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1297,12 +1297,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 24,
                 },
@@ -1313,7 +1313,7 @@ type Foo<T> = {
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1329,7 +1329,7 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1339,7 +1339,7 @@ type Foo<T> = {
             code: "type Foo = string;",
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1350,7 +1350,7 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1361,7 +1361,7 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1372,7 +1372,7 @@ type Foo<T> = {
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1383,7 +1383,7 @@ type Foo<T> = {
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1394,7 +1394,7 @@ type Foo<T> = {
             options: [{ allowAliases: "in-unions-and-intersections" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1404,12 +1404,12 @@ type Foo<T> = {
             code: "type Foo = string | string[];",
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1420,12 +1420,12 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1436,12 +1436,12 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1452,12 +1452,12 @@ type Foo<T> = {
             options: [{ allowAliases: false, allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1468,12 +1468,12 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1484,12 +1484,12 @@ type Foo<T> = {
             options: [{ allowAliases: "never", allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1500,12 +1500,12 @@ type Foo<T> = {
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1521,12 +1521,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -1536,17 +1536,17 @@ type Foo<T> = {
             code: "type Foo = string | string[] | number;",
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1557,17 +1557,17 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1578,17 +1578,17 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1599,17 +1599,17 @@ type Foo<T> = {
             options: [{ allowAliases: false, allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1620,17 +1620,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1641,17 +1641,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never", allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1662,17 +1662,17 @@ type Foo<T> = {
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1688,17 +1688,17 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1708,17 +1708,17 @@ type Foo<T> = {
             code: "type Foo = string | string[] & number;",
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1729,17 +1729,17 @@ type Foo<T> = {
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1750,17 +1750,17 @@ type Foo<T> = {
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1771,17 +1771,17 @@ type Foo<T> = {
             options: [{ allowAliases: false, allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1792,17 +1792,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1813,17 +1813,17 @@ type Foo<T> = {
             options: [{ allowAliases: "never", allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1834,12 +1834,12 @@ type Foo<T> = {
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1852,12 +1852,12 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -1868,7 +1868,7 @@ type Foo<T> = {
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1884,7 +1884,7 @@ type Foo<T> = {
             ],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1897,7 +1897,7 @@ type Foo = Bar;
             `,
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1911,7 +1911,7 @@ type Foo = Bar;
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1925,7 +1925,7 @@ type Foo = Bar;
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1939,7 +1939,7 @@ type Foo = Bar;
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1953,7 +1953,7 @@ type Foo = Bar;
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1967,7 +1967,7 @@ type Foo = Bar;
             options: [{ allowAliases: "in-unions-and-intersections" }],
             errors: [
                 {
-                    message: "Type aliases are not allowed",
+                    message: "Type aliases are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -1980,12 +1980,12 @@ type Foo = Bar | {};
             `,
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -1999,12 +1999,12 @@ type Foo = Bar | {};
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2018,12 +2018,12 @@ type Foo = Bar | {};
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2037,7 +2037,7 @@ type Foo = Bar | {};
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2051,12 +2051,12 @@ type Foo = Bar | {};
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2070,7 +2070,7 @@ type Foo = Bar | {};
             options: [{ allowAliases: "in-unions-and-intersections" }],
             errors: [
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2083,12 +2083,12 @@ type Foo = Bar & {};
             `,
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2102,12 +2102,12 @@ type Foo = Bar & {};
             options: [{ allowAliases: false }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2121,12 +2121,12 @@ type Foo = Bar & {};
             options: [{ allowAliases: "never" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2140,12 +2140,12 @@ type Foo = Bar & {};
             options: [{ allowAliases: "in-unions" }],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2159,7 +2159,7 @@ type Foo = Bar & {};
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2173,7 +2173,7 @@ type Foo = Bar & {};
             options: [{ allowAliases: "in-unions-and-intersections" }],
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 18,
                 },
@@ -2183,7 +2183,7 @@ type Foo = Bar & {};
             code: "type Foo = () => void;",
             errors: [
                 {
-                    message: "Type callbacks are not allowed",
+                    message: "Type callbacks are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2194,7 +2194,7 @@ type Foo = Bar & {};
             options: [{ allowCallbacks: false }],
             errors: [
                 {
-                    message: "Type callbacks are not allowed",
+                    message: "Type callbacks are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2205,7 +2205,7 @@ type Foo = Bar & {};
             options: [{ allowCallbacks: "never" }],
             errors: [
                 {
-                    message: "Type callbacks are not allowed",
+                    message: "Type callbacks are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2215,7 +2215,7 @@ type Foo = Bar & {};
             code: "type Foo = {};",
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2226,7 +2226,7 @@ type Foo = Bar & {};
             options: [{ allowLiterals: false }],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2237,7 +2237,7 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "never" }],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2248,7 +2248,7 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2259,7 +2259,7 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "in-intersections" }],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2270,7 +2270,7 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "in-unions-and-intersections" }],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2281,7 +2281,7 @@ type Foo = Bar & {};
             options: [{ allowAliases: "in-intersections" }],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2294,7 +2294,7 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2307,7 +2307,7 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2323,7 +2323,7 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2339,7 +2339,7 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2355,7 +2355,7 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Type literals are not allowed",
+                    message: "Type literals are not allowed.",
                     row: 1,
                     column: 12,
                 },
@@ -2365,12 +2365,12 @@ type Foo = Bar & {};
             code: "type Foo = {} | {};",
             errors: [
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2381,12 +2381,12 @@ type Foo = Bar & {};
             options: [{ allowLiterals: false }],
             errors: [
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2397,12 +2397,12 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "never" }],
             errors: [
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2413,12 +2413,12 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "in-intersections" }],
             errors: [
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in union types are not allowed",
+                    message: "Literals in union types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2428,12 +2428,12 @@ type Foo = Bar & {};
             code: "type Foo = {} & {};",
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2444,12 +2444,12 @@ type Foo = Bar & {};
             options: [{ allowLiterals: false }],
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2460,12 +2460,12 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "never" }],
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2476,12 +2476,12 @@ type Foo = Bar & {};
             options: [{ allowLiterals: "in-unions" }],
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 17,
                 },
@@ -2494,12 +2494,12 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Aliases in intersection types are not allowed",
+                    message: "Aliases in intersection types are not allowed.",
                     row: 1,
                     column: 12,
                 },
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
@@ -2515,17 +2515,17 @@ type Foo = Bar & {};
             ],
             errors: [
                 {
-                    message: "Literals in intersection types are not allowed",
+                    message: "Literals in intersection types are not allowed.",
                     row: 1,
                     column: 21,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 26,
                 },
                 {
-                    message: "Aliases in union types are not allowed",
+                    message: "Aliases in union types are not allowed.",
                     row: 1,
                     column: 32,
                 },
@@ -2539,7 +2539,7 @@ type Foo<T> = {
             `,
             errors: [
                 {
-                    message: "Type mapped types are not allowed",
+                    message: "Type mapped types are not allowed.",
                     row: 1,
                     column: 15,
                 },
@@ -2554,7 +2554,7 @@ type Foo<T> = {
             options: [{ allowMappedTypes: false }],
             errors: [
                 {
-                    message: "Type mapped types are not allowed",
+                    message: "Type mapped types are not allowed.",
                     row: 1,
                     column: 15,
                 },
@@ -2569,7 +2569,7 @@ type Foo<T> = {
             options: [{ allowMappedTypes: "never" }],
             errors: [
                 {
-                    message: "Type mapped types are not allowed",
+                    message: "Type mapped types are not allowed.",
                     row: 1,
                     column: 15,
                 },
@@ -2584,7 +2584,7 @@ type Foo<T> = {
             options: [{ allowMappedTypes: "in-unions" }],
             errors: [
                 {
-                    message: "Type mapped types are not allowed",
+                    message: "Type mapped types are not allowed.",
                     row: 1,
                     column: 15,
                 },
@@ -2599,7 +2599,7 @@ type Foo<T> = {
             options: [{ allowMappedTypes: "in-intersections" }],
             errors: [
                 {
-                    message: "Type mapped types are not allowed",
+                    message: "Type mapped types are not allowed.",
                     row: 1,
                     column: 15,
                 },
@@ -2614,7 +2614,7 @@ type Foo<T> = {
             options: [{ allowMappedTypes: "in-unions-and-intersections" }],
             errors: [
                 {
-                    message: "Type mapped types are not allowed",
+                    message: "Type mapped types are not allowed.",
                     row: 1,
                     column: 15,
                 },
@@ -2630,12 +2630,12 @@ type Foo<T> = {
             `,
             errors: [
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2652,12 +2652,12 @@ type Foo<T> = {
             options: [{ allowMappedTypes: false }],
             errors: [
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2674,12 +2674,12 @@ type Foo<T> = {
             options: [{ allowMappedTypes: "never" }],
             errors: [
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2696,12 +2696,12 @@ type Foo<T> = {
             options: [{ allowMappedTypes: "in-intersections" }],
             errors: [
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
-                    message: "Mapped types in union types are not allowed",
+                    message: "Mapped types in union types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2718,13 +2718,13 @@ type Foo<T> = {
             errors: [
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2742,13 +2742,13 @@ type Foo<T> = {
             errors: [
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2766,13 +2766,13 @@ type Foo<T> = {
             errors: [
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 4,
                     column: 5,
                 },
@@ -2790,13 +2790,13 @@ type Foo<T> = {
             errors: [
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 1,
                     column: 15,
                 },
                 {
                     message:
-                        "Mapped types in intersection types are not allowed",
+                        "Mapped types in intersection types are not allowed.",
                     row: 4,
                     column: 5,
                 },

--- a/tests/lib/rules/no-var-requires.js
+++ b/tests/lib/rules/no-var-requires.js
@@ -26,7 +26,7 @@ ruleTester.run("no-var-requires", rule, {
             code: "var foo = require('foo')",
             errors: [
                 {
-                    message: "Require statement not part of import statement",
+                    message: "Require statement not part of import statement.",
                     line: 1,
                     column: 11,
                 },
@@ -36,7 +36,7 @@ ruleTester.run("no-var-requires", rule, {
             code: "const foo = require('foo')",
             errors: [
                 {
-                    message: "Require statement not part of import statement",
+                    message: "Require statement not part of import statement.",
                     line: 1,
                     column: 13,
                 },
@@ -46,7 +46,7 @@ ruleTester.run("no-var-requires", rule, {
             code: "let foo = require('foo')",
             errors: [
                 {
-                    message: "Require statement not part of import statement",
+                    message: "Require statement not part of import statement.",
                     line: 1,
                     column: 11,
                 },

--- a/tests/lib/rules/prefer-namespace-keyword.js
+++ b/tests/lib/rules/prefer-namespace-keyword.js
@@ -35,7 +35,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
             errors: [
                 {
                     message:
-                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
                     row: 1,
                     column: 1,
                 },
@@ -47,7 +47,7 @@ ruleTester.run("prefer-namespace-keyword", rule, {
             errors: [
                 {
                     message:
-                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
                     row: 1,
                     column: 1,
                 },
@@ -67,13 +67,13 @@ declare namespace foo {
             errors: [
                 {
                     message:
-                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
                     row: 2,
                     column: 1,
                 },
                 {
                     message:
-                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules",
+                        "Use 'namespace' instead of 'module' to declare custom TypeScript modules.",
                     row: 3,
                     column: 5,
                 },

--- a/tests/lib/rules/type-annotation-spacing.js
+++ b/tests/lib/rules/type-annotation-spacing.js
@@ -1048,7 +1048,7 @@ type Bar = Record<keyof Foo, string>
             output: "let foo: string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 9,
                 },
@@ -1059,7 +1059,7 @@ type Bar = Record<keyof Foo, string>
             output: "function foo(): string {}",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 16,
                 },
@@ -1070,7 +1070,7 @@ type Bar = Record<keyof Foo, string>
             output: "function foo(a: string) {}",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 16,
                 },
@@ -1089,7 +1089,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1108,7 +1108,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 25,
                 },
@@ -1127,7 +1127,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1146,12 +1146,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1170,7 +1170,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1189,7 +1189,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1208,12 +1208,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1232,7 +1232,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1251,7 +1251,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1270,12 +1270,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1286,7 +1286,7 @@ type Foo = {
             output: "type Foo = (name: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 18,
                 },
@@ -1297,12 +1297,12 @@ type Foo = {
             output: "type Foo = (name: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -1321,7 +1321,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 18,
                 },
@@ -1340,12 +1340,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 27,
                 },
@@ -1357,7 +1357,7 @@ type Foo = {
             output: "let foo: string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 9,
                 },
@@ -1369,7 +1369,7 @@ type Foo = {
             output: "function foo(): string {}",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 16,
                 },
@@ -1381,7 +1381,7 @@ type Foo = {
             output: "function foo(a: string) {}",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 16,
                 },
@@ -1401,7 +1401,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1421,7 +1421,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 25,
                 },
@@ -1441,7 +1441,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1461,12 +1461,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1486,7 +1486,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1506,7 +1506,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1526,12 +1526,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1551,7 +1551,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1571,7 +1571,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1591,12 +1591,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1608,7 +1608,7 @@ type Foo = {
             output: "type Foo = (name: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 18,
                 },
@@ -1620,12 +1620,12 @@ type Foo = {
             output: "type Foo = (name: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -1645,7 +1645,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 18,
                 },
@@ -1665,12 +1665,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 27,
                 },
@@ -1682,7 +1682,7 @@ type Foo = {
             output: "let foo: string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 9,
                 },
@@ -1694,7 +1694,7 @@ type Foo = {
             output: "function foo(): string {}",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 16,
                 },
@@ -1706,7 +1706,7 @@ type Foo = {
             output: "function foo(a: string) {}",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 16,
                 },
@@ -1726,7 +1726,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1746,7 +1746,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 25,
                 },
@@ -1766,7 +1766,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1786,12 +1786,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1811,7 +1811,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1831,7 +1831,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1851,12 +1851,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1876,7 +1876,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 10,
                 },
@@ -1896,7 +1896,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 13,
                 },
@@ -1916,12 +1916,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 26,
                 },
@@ -1933,12 +1933,12 @@ type Foo = {
             output: "type Foo = (name: string)=> string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Unexpected space before the '=>'",
+                    message: "Unexpected space before the '=>'.",
                     line: 1,
                     column: 28,
                 },
@@ -1950,7 +1950,7 @@ type Foo = {
             output: "type Foo = (name: string)=> string;",
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 1,
                     column: 18,
                 },
@@ -1970,12 +1970,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected space before the '=>'",
+                    message: "Unexpected space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -1995,7 +1995,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 18,
                 },
@@ -2007,12 +2007,12 @@ type Foo = {
             output: "let foo : string;",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 8,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 8,
                 },
@@ -2024,12 +2024,12 @@ type Foo = {
             output: "function foo() : string {}",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 15,
                 },
@@ -2041,12 +2041,12 @@ type Foo = {
             output: "function foo(a : string) {}",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 15,
                 },
@@ -2066,12 +2066,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2091,12 +2091,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -2116,12 +2116,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -2141,22 +2141,22 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -2176,12 +2176,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2201,12 +2201,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -2226,22 +2226,22 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -2261,12 +2261,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2286,12 +2286,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -2311,22 +2311,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -2338,12 +2338,12 @@ type Foo = {
             output: "type Foo = (name : string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 26,
                 },
@@ -2355,7 +2355,7 @@ type Foo = {
             output: "type Foo = (name : string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -2375,17 +2375,17 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 10,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 26,
                 },
@@ -2405,7 +2405,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -2417,12 +2417,12 @@ type Foo = {
             output: "let foo : string;",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 8,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 8,
                 },
@@ -2434,12 +2434,12 @@ type Foo = {
             output: "function foo() : string {}",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 15,
                 },
@@ -2451,12 +2451,12 @@ type Foo = {
             output: "function foo(a : string) {}",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 15,
                 },
@@ -2476,12 +2476,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2501,12 +2501,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -2526,12 +2526,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -2551,22 +2551,22 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -2586,12 +2586,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2611,12 +2611,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -2636,22 +2636,22 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -2671,12 +2671,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2696,12 +2696,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -2721,22 +2721,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -2748,12 +2748,12 @@ type Foo = {
             output: "type Foo = (name : string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 26,
                 },
@@ -2765,7 +2765,7 @@ type Foo = {
             output: "type Foo = (name : string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -2785,17 +2785,17 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 10,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 26,
                 },
@@ -2815,7 +2815,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -2833,12 +2833,12 @@ type Foo = {
             output: "let foo : string;",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 8,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 8,
                 },
@@ -2856,12 +2856,12 @@ type Foo = {
             output: "function foo() : string {}",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 15,
                 },
@@ -2879,12 +2879,12 @@ type Foo = {
             output: "function foo(a : string) {}",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 15,
                 },
@@ -2910,12 +2910,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -2941,12 +2941,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -2972,12 +2972,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -3003,22 +3003,22 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -3044,12 +3044,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -3075,12 +3075,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -3106,22 +3106,22 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -3147,12 +3147,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 9,
                 },
@@ -3178,12 +3178,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 12,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 12,
                 },
@@ -3209,22 +3209,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 23,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 23,
                 },
@@ -3242,12 +3242,12 @@ type Foo = {
             output: "type Foo = (name : string)=>string;",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 17,
                 },
@@ -3273,12 +3273,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 18,
                 },
@@ -3305,22 +3305,22 @@ type Foo = {
             output: "type Foo = (name : string) => string;",
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space after the '=>'",
+                    message: "Expected a space after the '=>'.",
                     line: 1,
                     column: 25,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 25,
                 },
@@ -3355,22 +3355,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space after the '=>'",
+                    message: "Expected a space after the '=>'.",
                     line: 3,
                     column: 26,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 26,
                 },
@@ -3395,47 +3395,47 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 3,
                     column: 30,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 3,
                     column: 45,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 3,
                     column: 52,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 4,
                     column: 47,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 4,
                     column: 62,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 4,
                     column: 69,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 5,
                     column: 45,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 5,
                     column: 60,
                 },
                 {
-                    message: `Expected a space before the ':'`,
+                    message: `Expected a space before the ':'.`,
                     line: 5,
                     column: 67,
                 },
@@ -4236,7 +4236,7 @@ type Bar = Record<keyof Foo, string>
             output: "function foo(a?: string) {}",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 16,
                 },
@@ -4255,7 +4255,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4274,7 +4274,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 25,
                 },
@@ -4293,12 +4293,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4317,7 +4317,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4336,12 +4336,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4360,7 +4360,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4379,12 +4379,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4395,7 +4395,7 @@ type Foo = {
             output: "type Foo = (name?: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 18,
                 },
@@ -4406,12 +4406,12 @@ type Foo = {
             output: "type Foo = (name?: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 28,
                 },
@@ -4430,7 +4430,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
@@ -4449,12 +4449,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -4466,7 +4466,7 @@ type Foo = {
             output: "function foo(a?: string) {}",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 16,
                 },
@@ -4486,7 +4486,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4506,7 +4506,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 25,
                 },
@@ -4526,12 +4526,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4551,7 +4551,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4571,12 +4571,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4596,7 +4596,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4616,12 +4616,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4633,7 +4633,7 @@ type Foo = {
             output: "type Foo = (name?: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 18,
                 },
@@ -4645,12 +4645,12 @@ type Foo = {
             output: "type Foo = (name?: string) => string;",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 28,
                 },
@@ -4670,7 +4670,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
@@ -4690,12 +4690,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -4707,7 +4707,7 @@ type Foo = {
             output: "function foo(a?: string) {}",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 16,
                 },
@@ -4727,7 +4727,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4747,7 +4747,7 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 25,
                 },
@@ -4767,12 +4767,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4792,7 +4792,7 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4812,12 +4812,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4837,7 +4837,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4857,12 +4857,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Unexpected space before the ':'",
+                    message: "Unexpected space before the ':'.",
                     line: 3,
                     column: 27,
                 },
@@ -4874,12 +4874,12 @@ type Foo = {
             output: "type Foo = (name?: string)=> string;",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Unexpected space before the '=>'",
+                    message: "Unexpected space before the '=>'.",
                     line: 1,
                     column: 29,
                 },
@@ -4891,7 +4891,7 @@ type Foo = {
             output: "type Foo = (name?: string)=> string;",
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 1,
                     column: 18,
                 },
@@ -4911,12 +4911,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Unexpected space before the '=>'",
+                    message: "Unexpected space before the '=>'.",
                     line: 3,
                     column: 29,
                 },
@@ -4936,7 +4936,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Unexpected space before the '?:'",
+                    message: "Unexpected space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
@@ -4948,12 +4948,12 @@ type Foo = {
             output: "function foo(a ?: string) {}",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 1,
                     column: 16,
                 },
@@ -4973,12 +4973,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -4998,12 +4998,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 25,
                 },
@@ -5023,22 +5023,22 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5058,12 +5058,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5083,22 +5083,22 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5118,12 +5118,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5143,22 +5143,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5170,12 +5170,12 @@ type Foo = {
             output: "type Foo = (name ?: string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -5187,7 +5187,7 @@ type Foo = {
             output: "type Foo = (name ?: string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 28,
                 },
@@ -5207,17 +5207,17 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -5237,7 +5237,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 30,
                 },
@@ -5249,12 +5249,12 @@ type Foo = {
             output: "function foo(a ?: string) {}",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 1,
                     column: 16,
                 },
@@ -5274,12 +5274,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5299,12 +5299,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 25,
                 },
@@ -5324,22 +5324,22 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5359,12 +5359,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5384,22 +5384,22 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5419,12 +5419,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5444,22 +5444,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5471,12 +5471,12 @@ type Foo = {
             output: "type Foo = (name ?: string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -5488,7 +5488,7 @@ type Foo = {
             output: "type Foo = (name : string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 27,
                 },
@@ -5508,17 +5508,17 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 10,
                 },
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 18,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -5538,7 +5538,7 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 30,
                 },
@@ -5556,12 +5556,12 @@ type Foo = {
             output: "function foo(a ?: string) {}",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 1,
                     column: 16,
                 },
@@ -5587,12 +5587,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5618,12 +5618,12 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 25,
                 },
@@ -5649,22 +5649,22 @@ class Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5690,12 +5690,12 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5721,22 +5721,22 @@ interface Foo {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5762,12 +5762,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 9,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 10,
                 },
@@ -5793,22 +5793,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 15,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 16,
                 },
                 {
-                    message: "Expected a space after the ':'",
+                    message: "Expected a space after the ':'.",
                     line: 3,
                     column: 24,
                 },
                 {
-                    message: "Expected a space before the ':'",
+                    message: "Expected a space before the ':'.",
                     line: 3,
                     column: 24,
                 },
@@ -5826,12 +5826,12 @@ type Foo = {
             output: "type Foo = (name ?: string)=>string;",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 1,
                     column: 18,
                 },
@@ -5857,12 +5857,12 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 19,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 20,
                 },
@@ -5889,22 +5889,22 @@ type Foo = {
             output: "type Foo = (name ?: string) => string;",
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 1,
                     column: 17,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 1,
                     column: 18,
                 },
                 {
-                    message: "Expected a space after the '=>'",
+                    message: "Expected a space after the '=>'.",
                     line: 1,
                     column: 26,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 1,
                     column: 26,
                 },
@@ -5939,22 +5939,22 @@ type Foo = {
             `,
             errors: [
                 {
-                    message: "Expected a space before the '?:'",
+                    message: "Expected a space before the '?:'.",
                     line: 3,
                     column: 19,
                 },
                 {
-                    message: "Expected a space after the '?:'",
+                    message: "Expected a space after the '?:'.",
                     line: 3,
                     column: 20,
                 },
                 {
-                    message: "Expected a space after the '=>'",
+                    message: "Expected a space after the '=>'.",
                     line: 3,
                     column: 28,
                 },
                 {
-                    message: "Expected a space before the '=>'",
+                    message: "Expected a space before the '=>'.",
                     line: 3,
                     column: 28,
                 },
@@ -6022,7 +6022,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
@@ -6034,7 +6034,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
@@ -6046,7 +6046,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
@@ -6058,12 +6058,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
                         {
-                            message: `Unexpected space after the '${operator}'`,
+                            message: `Unexpected space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6075,12 +6075,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
                         {
-                            message: `Unexpected space after the '${operator}'`,
+                            message: `Unexpected space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6092,7 +6092,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space after the '${operator}'`,
+                            message: `Unexpected space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6105,7 +6105,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },
@@ -6117,12 +6117,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space before the '${operator}'`,
+                            message: `Expected a space before the '${operator}'.`,
                             line: 1,
                             column: 31,
                         },
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },
@@ -6134,12 +6134,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space before the '${operator}'`,
+                            message: `Expected a space before the '${operator}'.`,
                             line: 1,
                             column: 31,
                         },
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },
@@ -6151,7 +6151,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },
@@ -6163,7 +6163,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space before the '${operator}'`,
+                            message: `Expected a space before the '${operator}'.`,
                             line: 1,
                             column: 31,
                         },
@@ -6176,12 +6176,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6193,12 +6193,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6210,7 +6210,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6222,12 +6222,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space before the '${operator}'`,
+                            message: `Unexpected space before the '${operator}'.`,
                             line: 1,
                             column: 32,
                         },
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6239,7 +6239,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space after the '${operator}'`,
+                            message: `Expected a space after the '${operator}'.`,
                             line: 1,
                             column: 34,
                         },
@@ -6252,7 +6252,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space after the '${operator}'`,
+                            message: `Unexpected space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },
@@ -6264,7 +6264,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space before the '${operator}'`,
+                            message: `Expected a space before the '${operator}'.`,
                             line: 1,
                             column: 31,
                         },
@@ -6276,7 +6276,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator} T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space before the '${operator}'`,
+                            message: `Expected a space before the '${operator}'.`,
                             line: 1,
                             column: 31,
                         },
@@ -6288,12 +6288,12 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T] ${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Expected a space before the '${operator}'`,
+                            message: `Expected a space before the '${operator}'.`,
                             line: 1,
                             column: 31,
                         },
                         {
-                            message: `Unexpected space after the '${operator}'`,
+                            message: `Unexpected space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },
@@ -6305,7 +6305,7 @@ ruleTester.run("type-annotation-spacing", rule, {
                     output: `type Foo<T> = { [P in keyof T]${operator}T[P] }`,
                     errors: [
                         {
-                            message: `Unexpected space after the '${operator}'`,
+                            message: `Unexpected space after the '${operator}'.`,
                             line: 1,
                             column: 33,
                         },


### PR DESCRIPTION
I also did small cleanup of test messages in `generic-type-naming.js`
https://github.com/bradzacher/eslint-plugin-typescript/pull/220/files#diff-978785a06f9d7e99cbb60013eac7bea4

when you are using `messageId` you are allowed to use data property, than we don't need custom functions

### config:

```json
 "eslint-plugin/report-message-format": ["error", "^[A-Z'{].*[\\.}]$"]
```

fixes: #215