### PR TITLE
[FEAT] Add rule no-object-literal-type-assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This guarantees 100% compatibility between the plugin and the parser.
 * [`typescript/no-inferrable-types`](./docs/rules/no-inferrable-types.md) — Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean. (`no-inferrable-types` from TSLint)
 * [`typescript/no-namespace`](./docs/rules/no-namespace.md) — Disallow the use of custom TypeScript modules and namespaces
 * [`typescript/no-non-null-assertion`](./docs/rules/no-non-null-assertion.md) — Disallows non-null assertions using the `!` postfix operator (`no-non-null-assertion` from TSLint)
+* [`typescript/no-object-literal-type-assertion`](./docs/rules/no-object-literal-type-assertion.md) — Forbids an object literal to appear in a type assertion expression (`no-object-literal-type-assertion` from TSLint)
 * [`typescript/no-parameter-properties`](./docs/rules/no-parameter-properties.md) — Disallow the use of parameter properties in class constructors. (`no-parameter-properties` from TSLint)
 * [`typescript/no-triple-slash-reference`](./docs/rules/no-triple-slash-reference.md) — Disallow `/// <reference path="" />` comments (`no-reference` from TSLint)
 * [`typescript/no-type-alias`](./docs/rules/no-type-alias.md) — Disallow the use of type aliases (`interface-over-type-literal` from TSLint)

--- a/docs/rules/no-object-literal-type-assertion.md
+++ b/docs/rules/no-object-literal-type-assertion.md
@@ -1,0 +1,28 @@
+# Forbids an object literal to appear in a type assertion expression (no-object-literal-type-assertion)
+
+Always prefer `const x: T = { ... };` to `const x = { ... } as T;`
+
+## Rule Details
+
+Examples of **incorrect** code for this rule.
+
+```ts
+const x = { ... } as T;
+```
+
+Examples of **correct** code for this rule.
+
+```ts
+const x: T = { ... };
+```
+
+## Options
+```json
+{
+    "typescript/no-object-literal-type-assertion": "error"
+}
+```
+
+## Compatibility
+
+* TSLint: [no-object-literal-type-assertion](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/)

--- a/docs/rules/no-object-literal-type-assertion.md
+++ b/docs/rules/no-object-literal-type-assertion.md
@@ -1,6 +1,6 @@
 # Forbids an object literal to appear in a type assertion expression (no-object-literal-type-assertion)
 
-Always prefer `const x: T = { ... };` to `const x = { ... } as T;`
+Always prefer `const x: T = { ... };` to `const x = { ... } as T;`. Casting to `any` and `unknown` is still allowed.
 
 ## Rule Details
 
@@ -14,6 +14,8 @@ Examples of **correct** code for this rule.
 
 ```ts
 const x: T = { ... };
+const y = { ... } as any;
+const z = { ... } as unknown;
 ```
 
 ## Options

--- a/lib/rules/no-object-literal-type-assertion.js
+++ b/lib/rules/no-object-literal-type-assertion.js
@@ -19,8 +19,7 @@ module.exports = {
                 util.tslintRule("no-object-literal-type-assertion"),
             ],
             category: "TypeScript",
-            url:
-                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-object-literal-type-assertion.md",
+            url: util.metaDocsUrl("no-object-literal-type-assertions"),
         },
         messages: {
             unexpectedTypeAssertion:

--- a/lib/rules/no-object-literal-type-assertion.js
+++ b/lib/rules/no-object-literal-type-assertion.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Forbids an object literal to appear in a type assertion expression
+ * @author Armano <https://github.com/armano2>
+ */
+"use strict";
+
+const util = require("../util");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "Forbids an object literal to appear in a type assertion expression",
+            extraDescription: [
+                util.tslintRule("no-object-literal-type-assertion"),
+            ],
+            category: "TypeScript",
+            url:
+                "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-object-literal-type-assertion.md",
+        },
+        messages: {
+            errorMessage:
+                "Type assertion on object literals is forbidden, use a type annotation instead.",
+        },
+        schema: [],
+    },
+    create(context) {
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        /**
+         * Check whatever node should be reported
+         * @param {ASTNode} node the node to be evaluated.
+         * @returns {*} true or false
+         */
+        function checkType(node) {
+            if (
+                node &&
+                node.type === "TSTypeAnnotation" &&
+                node.typeAnnotation
+            ) {
+                switch (node.typeAnnotation.type) {
+                    case "TSAnyKeyword":
+                    case "TSUnknownKeyword":
+                        return false;
+                    default:
+                        break;
+                }
+            }
+            return true;
+        }
+
+        return {
+            "TSTypeAssertionExpression, TSAsExpression"(node) {
+                if (
+                    checkType(node.typeAnnotation) &&
+                    node.expression.type === "ObjectExpression"
+                ) {
+                    context.report({
+                        node,
+                        messageId: "errorMessage",
+                    });
+                }
+            },
+        };
+    },
+};

--- a/lib/rules/no-object-literal-type-assertion.js
+++ b/lib/rules/no-object-literal-type-assertion.js
@@ -23,7 +23,7 @@ module.exports = {
                 "https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-object-literal-type-assertion.md",
         },
         messages: {
-            errorMessage:
+            unexpectedTypeAssertion:
                 "Type assertion on object literals is forbidden, use a type annotation instead.",
         },
         schema: [],
@@ -63,7 +63,7 @@ module.exports = {
                 ) {
                     context.report({
                         node,
-                        messageId: "errorMessage",
+                        messageId: "unexpectedTypeAssertion",
                     });
                 }
             },

--- a/tests/lib/rules/no-object-literal-type-assertion.js
+++ b/tests/lib/rules/no-object-literal-type-assertion.js
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Forbids an object literal to appear in a type assertion expression
+ * @author Armano <https://github.com/armano2>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-object-literal-type-assertion"),
+    RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+    parser: "typescript-eslint-parser",
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: "module",
+        ecmaFeatures: {
+            jsx: false,
+        },
+    },
+});
+
+ruleTester.run("no-object-literal-type-assertion", rule, {
+    valid: [
+        {
+            code: `<T> x;`,
+        },
+        {
+            code: `x as T;`,
+        },
+        {
+            code: `const foo = bar;`,
+        },
+        {
+            code: `const foo: baz = bar;`,
+        },
+        {
+            code: `const x: T = {};`,
+        },
+        {
+            code: `const foo = { bar: { } };`,
+        },
+        // Allow cast to 'any'
+        {
+            code: `const foo = {} as any;`,
+        },
+        {
+            code: `const foo = <any> {};`,
+        },
+        // Allow cast to 'unknown'
+        {
+            code: `const foo = {} as unknown;`,
+        },
+        {
+            code: `const foo = <unknown> {};`,
+        },
+    ],
+    invalid: [
+        {
+            code: `<T> ({});`,
+            errors: [
+                {
+                    messageId: "errorMessage",
+                    line: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `({}) as T;`,
+            errors: [
+                {
+                    messageId: "errorMessage",
+                    line: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `const x = {} as T;`,
+            errors: [
+                {
+                    messageId: "errorMessage",
+                    line: 1,
+                    column: 11,
+                },
+            ],
+        },
+    ],
+});

--- a/tests/lib/rules/no-object-literal-type-assertion.js
+++ b/tests/lib/rules/no-object-literal-type-assertion.js
@@ -66,7 +66,7 @@ ruleTester.run("no-object-literal-type-assertion", rule, {
             code: `<T> ({});`,
             errors: [
                 {
-                    messageId: "errorMessage",
+                    messageId: "unexpectedTypeAssertion",
                     line: 1,
                     column: 1,
                 },
@@ -76,7 +76,7 @@ ruleTester.run("no-object-literal-type-assertion", rule, {
             code: `({}) as T;`,
             errors: [
                 {
-                    messageId: "errorMessage",
+                    messageId: "unexpectedTypeAssertion",
                     line: 1,
                     column: 1,
                 },
@@ -86,7 +86,7 @@ ruleTester.run("no-object-literal-type-assertion", rule, {
             code: `const x = {} as T;`,
             errors: [
                 {
-                    messageId: "errorMessage",
+                    messageId: "unexpectedTypeAssertion",
                     line: 1,
                     column: 11,
                 },


### PR DESCRIPTION
This PR implements rule [no-object-literal-type-assertion](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/)

- #5