### PR TITLE
Fix false positives in no-triple-slash-reference

### DIFF
--- a/lib/rules/no-triple-slash-reference.js
+++ b/lib/rules/no-triple-slash-reference.js
@@ -19,10 +19,13 @@ module.exports = {
             url: util.metaDocsUrl("no-triple-slash-reference"),
         },
         schema: [],
+        messages: {
+            tripleSlashReference: "Do not use a triple slash reference.",
+        },
     },
 
     create(context) {
-        const referenceRegExp = /^\/\s*<reference/;
+        const referenceRegExp = /^\/\s*<reference\s*path=/;
         const sourceCode = context.getSourceCode();
 
         //----------------------------------------------------------------------
@@ -45,7 +48,7 @@ module.exports = {
                 if (referenceRegExp.test(comment.value)) {
                     context.report({
                         node: comment,
-                        message: "Do not use a triple slash reference.",
+                        messageId: "tripleSlashReference",
                     });
                 }
             });

--- a/tests/lib/rules/no-triple-slash-reference.js
+++ b/tests/lib/rules/no-triple-slash-reference.js
@@ -21,15 +21,22 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("no-triple-slash-reference", rule, {
     valid: [
+        `/// <reference types="foo" />`,
+        `/// <reference lib="es2017.string" />`,
+        `/// <reference no-default-lib="true"/>`,
         "/// Non-reference triple-slash comment",
         "// <reference path='Animal' />",
+        `/*
+/// <reference path="Animal" />
+let a
+*/`,
     ],
     invalid: [
         {
             code: '/// <reference path="Animal" />',
             errors: [
                 {
-                    message: "Do not use a triple slash reference.",
+                    messageId: "tripleSlashReference",
                     line: 1,
                     column: 1,
                 },
@@ -43,7 +50,7 @@ let a
             parser: "typescript-eslint-parser",
             errors: [
                 {
-                    message: "Do not use a triple slash reference.",
+                    messageId: "tripleSlashReference",
                     line: 2,
                     column: 1,
                 },


### PR DESCRIPTION
### Disallow `/// <reference path="" />` comments

but it's triggered on:
- `/// <reference types="foo" />`
- `/// <reference lib="es2017.string" />`
- `/// <reference no-default-lib="true"/>`

types/lib/no-default-lib can't be replaced by es6 imports