### PR TITLE
[CHORE] Fix issue with line ending chars in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 *.js text eol=lf
 *.jsx text eol=lf
 *.d.ts text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.json text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,4 @@
 # avoids End-of-line problems for Windows Devs
 # automatically converts crlf -> lf
 #   (linters can turn off their line-ending checks)
-*.ts text eol=lf
-*.tsx text eol=lf
-*.js text eol=lf
-*.jsx text eol=lf
-*.d.ts text eol=lf
-*.md text eol=lf
-*.yml text eol=lf
-*.json text eol=lf
+* text eol=lf


### PR DESCRIPTION
When user has `git core.autocrlf` set to crlf on windows machines there are collisions between `eslint-docs` and `prettier` due to inconsistent line endings in md files.

fixes: #249

@uniqueiniquity