### PR TITLE
[FIX] Refactor no-namespace rule

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -13,7 +13,15 @@ exports.metaDocsUrl = name =>
  * @returns {boolean} `true` if the file name ends in *.ts or *.tsx
  * @private
  */
-exports.isTypescript = fileName => /\.tsx?$/.test(fileName);
+exports.isTypescript = fileName => /\.tsx?$/i.test(fileName || "");
+
+/**
+ * Check if the context file name is *.d.ts or *.d.ts
+ * @param {string} fileName The context file name
+ * @returns {boolean} `true` if the file name ends in *.d.ts or *.d.ts
+ * @private
+ */
+exports.isDefinitionFile = fileName => /\.d\.tsx?$/i.test(fileName || "");
 
 /**
  * Pure function - doesn't mutate either parameter!

--- a/tests/lib/rules/no-namespace.js
+++ b/tests/lib/rules/no-namespace.js
@@ -64,18 +64,6 @@ ruleTester.run("no-namespace", rule, {
             ],
         },
         {
-            // TSModuleDeclaration -> TSModuleDeclaration -> TSModuleBody
-            code: "namespace Foo.Bar {}",
-            options: [{ allowDeclarations: false }],
-            errors: [
-                {
-                    messageId: "moduleSyntaxIsPreferred",
-                    row: 1,
-                    column: 1,
-                },
-            ],
-        },
-        {
             code: "module foo {}",
             options: [{ allowDeclarations: false }],
             errors: [
@@ -184,6 +172,38 @@ ruleTester.run("no-namespace", rule, {
                     messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
+                },
+            ],
+        },
+        {
+            code: "namespace Foo.Bar {}",
+            options: [{ allowDeclarations: false }],
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            code: `
+                namespace Foo.Bar {
+                    namespace Baz.Bas {
+                        interface X {}
+                    }
+                }
+            `,
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 17,
+                },
+                {
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 2,
+                    column: 21,
                 },
             ],
         },

--- a/tests/lib/rules/no-namespace.js
+++ b/tests/lib/rules/no-namespace.js
@@ -31,14 +31,23 @@ ruleTester.run("no-namespace", rule, {
             code: "declare namespace foo { }",
             options: [{ allowDeclarations: true }],
         },
+        {
+            filename: "test.d.ts",
+            code: "namespace foo { }",
+            options: [{ allowDefinitionFiles: true }],
+        },
+        {
+            filename: "test.d.ts",
+            code: "module foo { }",
+            options: [{ allowDefinitionFiles: true }],
+        },
     ],
     invalid: [
         {
             code: "module foo {}",
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -48,8 +57,19 @@ ruleTester.run("no-namespace", rule, {
             code: "namespace foo {}",
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            // TSModuleDeclaration -> TSModuleDeclaration -> TSModuleBody
+            code: "namespace Foo.Bar {}",
+            options: [{ allowDeclarations: false }],
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -60,8 +80,7 @@ ruleTester.run("no-namespace", rule, {
             options: [{ allowDeclarations: false }],
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -72,8 +91,7 @@ ruleTester.run("no-namespace", rule, {
             options: [{ allowDeclarations: false }],
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -83,8 +101,7 @@ ruleTester.run("no-namespace", rule, {
             code: "declare module foo { }",
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -94,8 +111,7 @@ ruleTester.run("no-namespace", rule, {
             code: "declare namespace foo { }",
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -106,8 +122,7 @@ ruleTester.run("no-namespace", rule, {
             options: [{ allowDeclarations: false }],
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },
@@ -118,8 +133,55 @@ ruleTester.run("no-namespace", rule, {
             options: [{ allowDeclarations: false }],
             errors: [
                 {
-                    message:
-                        "ES2015 module syntax is preferred over custom TypeScript modules and namespaces.",
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            filename: "test.d.ts",
+            code: "namespace foo { }",
+            options: [{ allowDefinitionFiles: false }],
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            filename: "test.d.ts",
+            code: "module foo { }",
+            options: [{ allowDefinitionFiles: false }],
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            filename: "test.d.ts",
+            code: "declare module foo {}",
+            options: [{ allowDefinitionFiles: false }],
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
+                    row: 1,
+                    column: 1,
+                },
+            ],
+        },
+        {
+            filename: "test.d.ts",
+            code: "declare namespace foo {}",
+            options: [{ allowDefinitionFiles: false }],
+            errors: [
+                {
+                    messageId: "moduleSyntaxIsPreferred",
                     row: 1,
                     column: 1,
                 },

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -1,0 +1,52 @@
+"use strict";
+const assert = require("assert");
+
+const util = require("../../lib/util");
+
+describe("isTypescript", () => {
+    it("should return false", () => {
+        assert.strictEqual(util.isTypescript("test.js"), false);
+        assert.strictEqual(util.isTypescript("test.jsx"), false);
+        assert.strictEqual(util.isTypescript("README.md"), false);
+        assert.strictEqual(util.isTypescript("test.d.js"), false);
+        assert.strictEqual(util.isTypescript("test.ts.js"), false);
+        assert.strictEqual(util.isTypescript("test.ts.map"), false);
+        assert.strictEqual(util.isTypescript("test.ts-js"), false);
+        assert.strictEqual(util.isTypescript("ts"), false);
+    });
+
+    it("should return true", () => {
+        assert.strictEqual(util.isTypescript("test.ts"), true);
+        assert.strictEqual(util.isTypescript("test.tsx"), true);
+        assert.strictEqual(util.isTypescript("test.TS"), true);
+        assert.strictEqual(util.isTypescript("test.TSX"), true);
+        assert.strictEqual(util.isTypescript("test.d.ts"), true);
+        assert.strictEqual(util.isTypescript("test.d.tsx"), true);
+        assert.strictEqual(util.isTypescript("test.D.TS"), true);
+        assert.strictEqual(util.isTypescript("test.D.TSX"), true);
+    });
+});
+
+describe("isDefinitionFile", () => {
+    it("should return false", () => {
+        assert.strictEqual(util.isDefinitionFile("test.js"), false);
+        assert.strictEqual(util.isDefinitionFile("test.jsx"), false);
+        assert.strictEqual(util.isDefinitionFile("README.md"), false);
+        assert.strictEqual(util.isDefinitionFile("test.d.js"), false);
+        assert.strictEqual(util.isDefinitionFile("test.ts.js"), false);
+        assert.strictEqual(util.isDefinitionFile("test.ts.map"), false);
+        assert.strictEqual(util.isDefinitionFile("test.ts-js"), false);
+        assert.strictEqual(util.isDefinitionFile("test.ts"), false);
+        assert.strictEqual(util.isDefinitionFile("ts"), false);
+        assert.strictEqual(util.isDefinitionFile("test.tsx"), false);
+        assert.strictEqual(util.isDefinitionFile("test.TS"), false);
+        assert.strictEqual(util.isDefinitionFile("test.TSX"), false);
+    });
+
+    it("should return true", () => {
+        assert.strictEqual(util.isDefinitionFile("test.d.ts"), true);
+        assert.strictEqual(util.isDefinitionFile("test.d.tsx"), true);
+        assert.strictEqual(util.isDefinitionFile("test.D.TS"), true);
+        assert.strictEqual(util.isDefinitionFile("test.D.TSX"), true);
+    });
+});


### PR DESCRIPTION
This PR changes logic in no-namespace rule and fixing some annoying bugs

- improve definition file detection
- migrate messages to messageId
- correct reporting `namespace Foo.Bar {}`
- add unit tests for isDefinitionFile & isTypescript
- add tests for allowDefinitionFiles
- [x] I’ve added tests for my changes
